### PR TITLE
feat: upgrade RAG with Docling and LightRAG graph retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,18 @@ OPENAI_MODEL=gpt-4o-mini
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama2
 
+# Parser engine: "auto" (docling with legacy fallback), "docling", "legacy"
+PARSER_ENGINE=auto
+
 # Vector store / Knowledge base
 VECTOR_STORE_TYPE=chroma
 CHROMA_PERSIST_DIR=./data/chroma
 EMBEDDING_MODEL=all-MiniLM-L6-v2
+
+# Graph RAG (LightRAG) — hybrid = vector + graph retrieval
+ENABLE_GRAPH_RAG=true
+LIGHTRAG_WORKING_DIR=./data/lightrag
+GRAPH_RAG_QUERY_MODE=hybrid
 
 # Optional: AAD (see docs/04-integration-guide.md)
 # AAD_TENANT_ID=

--- a/app/agent/orchestrator.py
+++ b/app/agent/orchestrator.py
@@ -38,7 +38,7 @@ async def run_assessment(
     doc_context = _build_document_context(parsed_documents)
 
     # Pass skill context to agents
-    policy_chunks, history_chunks = _policy_and_history_agent(
+    policy_chunks, history_chunks = await _policy_and_history_agent(
         doc_context["query_seed"],
         skill_focus=skill.risk_focus
     )
@@ -83,7 +83,7 @@ def _build_document_context(parsed_documents: list[ParsedDocument]) -> dict:
 
 
 
-def _policy_and_history_agent(
+async def _policy_and_history_agent(
     query_seed: str,
     skill_focus: list[str] | None = None
 ) -> tuple[list, list]:
@@ -98,7 +98,8 @@ def _policy_and_history_agent(
     policy_chunks = []
     history_chunks = []
     try:
-        policy_chunks = kb.query(search_query, top_k=5)
+        # Hybrid query: vector + graph RAG (when enabled)
+        policy_chunks = await kb.query(search_query, top_k=5)
     except Exception:
         policy_chunks = []
     try:
@@ -210,9 +211,17 @@ def _format_chunks_with_ids(chunks: list, prefix: str) -> str:
     for i, d in enumerate(chunks):
         metadata = d.metadata or {}
         src = metadata.get("source", "unknown")
-        page = metadata.get("page")
+        source_type = metadata.get("source_type", "vector")
         c_id = f"{prefix}-{i + 1}"
-        formatted.append(f"[{c_id}] {src} p={page}\n{d.page_content[:600]}")
+
+        if source_type == "graph":
+            graph_mode = metadata.get("graph_mode", "hybrid")
+            formatted.append(
+                f"[{c_id}] [GRAPH/{graph_mode}] {src}\n{d.page_content[:600]}"
+            )
+        else:
+            page = metadata.get("page")
+            formatted.append(f"[{c_id}] {src} p={page}\n{d.page_content[:600]}")
     return "\n\n".join(formatted)
 
 

--- a/app/api/kb.py
+++ b/app/api/kb.py
@@ -1,4 +1,4 @@
-"""Knowledge base API: upload document, query (RAG)."""
+"""Knowledge base API: upload document, query (hybrid RAG)."""
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 from pydantic import BaseModel
@@ -20,7 +20,7 @@ class KBReindexRequest(BaseModel):
 
 @router.post("/documents")
 async def upload_document(file: UploadFile = File(...)):  # noqa: B008
-    """Upload a document to the knowledge base."""
+    """Upload a document to the knowledge base (vector + graph RAG)."""
     from app.core.config import settings
 
     content = await file.read()
@@ -31,15 +31,15 @@ async def upload_document(file: UploadFile = File(...)):  # noqa: B008
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
     kb = KnowledgeBaseService()
-    doc_id = kb.add_document(parsed)
+    doc_id = await kb.add_document(parsed)
     return {"document_id": doc_id}
 
 
 @router.post("/query")
 async def query_kb(body: KBQueryRequest):
-    """RAG query over the knowledge base."""
+    """Hybrid RAG query: vector similarity + graph retrieval."""
     kb = KnowledgeBaseService()
-    docs = kb.query(body.query, top_k=body.top_k)
+    docs = await kb.query(body.query, top_k=body.top_k)
     return {
         "chunks": [{"content": d.page_content, "metadata": d.metadata} for d in docs]
     }
@@ -48,4 +48,4 @@ async def query_kb(body: KBQueryRequest):
 @router.post("/reindex")
 async def reindex_kb(body: KBReindexRequest):
     kb = KnowledgeBaseService()
-    return kb.reindex_directory(body.directory)
+    return await kb.reindex_directory(body.directory)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,12 +35,20 @@ class Settings(BaseSettings):
     OLLAMA_BASE_URL: str = "http://localhost:11434"
     OLLAMA_MODEL: str = "llama2"
 
+    # Parser engine: "docling", "legacy", or "auto" (docling with fallback)
+    PARSER_ENGINE: Literal["docling", "legacy", "auto"] = "auto"
+
     # Vector / KB
     VECTOR_STORE_TYPE: Literal["chroma"] = "chroma"
     CHROMA_PERSIST_DIR: str = "./data/chroma"
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"
     KB_AUTO_SYNC_DIR: str = "./examples"
     KB_AUTO_SYNC_INTERVAL_SECONDS: int = 0
+
+    # Graph RAG (LightRAG)
+    ENABLE_GRAPH_RAG: bool = True
+    LIGHTRAG_WORKING_DIR: str = "./data/lightrag"
+    GRAPH_RAG_QUERY_MODE: Literal["naive", "local", "global", "hybrid"] = "hybrid"
 
     @property
     def upload_max_bytes(self) -> int:

--- a/app/kb/__init__.py
+++ b/app/kb/__init__.py
@@ -1,3 +1,4 @@
+from .graph_rag import GraphRAGService, get_graph_rag_service
 from .service import KnowledgeBaseService
 
-__all__ = ["KnowledgeBaseService"]
+__all__ = ["KnowledgeBaseService", "GraphRAGService", "get_graph_rag_service"]

--- a/app/kb/graph_rag.py
+++ b/app/kb/graph_rag.py
@@ -1,0 +1,194 @@
+"""
+Graph-based RAG service using LightRAG.
+
+Builds a knowledge graph from ingested documents, enabling entity-relationship
+aware retrieval. Particularly valuable for cybersecurity documents where
+controls, frameworks, vulnerabilities, and policies form a connected graph
+(e.g., "ISO 27001 A.9.4.1" → "access control" → "password policy").
+
+Supports four query modes:
+  - naive: vector similarity only (like traditional RAG)
+  - local: entity-centric graph traversal
+  - global: community-level summaries
+  - hybrid: combines all modes for best results
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Lazy singleton to avoid repeated initialization
+_instance: "GraphRAGService | None" = None
+_instance_lock = asyncio.Lock()
+
+
+async def get_graph_rag_service() -> "GraphRAGService":
+    """Get or create the singleton GraphRAGService (with async init)."""
+    global _instance
+    if _instance is not None:
+        return _instance
+    async with _instance_lock:
+        if _instance is not None:
+            return _instance
+        svc = GraphRAGService()
+        await svc.initialize()
+        _instance = svc
+        return _instance
+
+
+class GraphRAGService:
+    """Wrapper around LightRAG for graph-based knowledge retrieval."""
+
+    def __init__(self) -> None:
+        self._rag = None
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize LightRAG instance with project LLM and embedding config."""
+        if self._initialized:
+            return
+
+        from lightrag import LightRAG
+        from lightrag.utils import EmbeddingFunc
+
+        working_dir = Path(settings.LIGHTRAG_WORKING_DIR)
+        working_dir.mkdir(parents=True, exist_ok=True)
+
+        self._rag = LightRAG(
+            working_dir=str(working_dir),
+            llm_model_func=self._llm_adapter,
+            llm_model_name=self._get_model_name(),
+            embedding_func=EmbeddingFunc(
+                embedding_dim=384,  # all-MiniLM-L6-v2 outputs 384-dim vectors
+                max_token_size=512,
+                func=self._embedding_adapter,
+            ),
+            chunk_token_size=1200,
+            chunk_overlap_token_size=100,
+        )
+        await self._rag.initialize_storages()
+        self._initialized = True
+        logger.info("GraphRAG initialized at %s", working_dir)
+
+    def _get_model_name(self) -> str:
+        if settings.LLM_PROVIDER == "openai":
+            return settings.OPENAI_MODEL
+        return settings.OLLAMA_MODEL
+
+    async def _llm_adapter(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        history_messages: list | None = None,
+        keyword_extraction: bool = False,
+        **kwargs,
+    ) -> str:
+        """Adapt project LLM to LightRAG's expected function signature."""
+        from app.llm.base import invoke_llm
+
+        sys_prompt = system_prompt or "You are a helpful assistant."
+        return await invoke_llm(sys_prompt, prompt)
+
+    async def _embedding_adapter(
+        self, texts: list[str], **kwargs
+    ) -> np.ndarray:
+        """Adapt project embedding model to LightRAG's expected signature."""
+        from langchain_community.embeddings import HuggingFaceEmbeddings
+
+        embeddings = HuggingFaceEmbeddings(
+            model_name=settings.EMBEDDING_MODEL,
+            model_kwargs={"device": "cpu"},
+        )
+        vectors = embeddings.embed_documents(texts)
+        return np.array(vectors)
+
+    async def insert(self, text: str, metadata: dict | None = None) -> None:
+        """Insert document text into the knowledge graph."""
+        if not self._initialized or not self._rag:
+            await self.initialize()
+        try:
+            await self._rag.ainsert(text)
+            source = (metadata or {}).get("source", "unknown")
+            logger.info("GraphRAG: inserted document from %s", source)
+        except Exception as e:
+            logger.error("GraphRAG insert failed: %s", e)
+
+    async def query(
+        self,
+        query: str,
+        mode: str | None = None,
+        top_k: int = 5,
+    ) -> list[dict]:
+        """
+        Query the knowledge graph.
+
+        Returns list of dicts with keys: content, metadata.
+        """
+        if not self._initialized or not self._rag:
+            await self.initialize()
+
+        from lightrag import QueryParam
+
+        query_mode = mode or settings.GRAPH_RAG_QUERY_MODE
+
+        try:
+            result = await self._rag.aquery(
+                query,
+                param=QueryParam(
+                    mode=query_mode,
+                    only_need_context=True,
+                    top_k=top_k,
+                ),
+            )
+
+            if not result:
+                return []
+
+            # LightRAG returns a string when only_need_context=True;
+            # split into meaningful chunks for downstream consumption
+            chunks = self._split_graph_context(result, query_mode)
+            return chunks
+
+        except Exception as e:
+            logger.error("GraphRAG query failed: %s", e)
+            return []
+
+    def _split_graph_context(
+        self, context: str, mode: str
+    ) -> list[dict]:
+        """Split LightRAG context string into structured chunk dicts."""
+        if not context or not context.strip():
+            return []
+
+        # Split by double newlines to get logical sections
+        sections = [s.strip() for s in context.split("\n\n") if s.strip()]
+
+        chunks = []
+        for i, section in enumerate(sections):
+            if len(section) < 20:  # skip trivially short fragments
+                continue
+            chunks.append(
+                {
+                    "content": section,
+                    "metadata": {
+                        "source": "graph_rag",
+                        "source_type": "graph",
+                        "graph_mode": mode,
+                        "chunk_index": i,
+                    },
+                }
+            )
+        return chunks
+
+    async def finalize(self) -> None:
+        """Clean up LightRAG resources."""
+        if self._rag and self._initialized:
+            await self._rag.finalize_storages()
+            self._initialized = False
+            logger.info("GraphRAG finalized")

--- a/app/kb/service.py
+++ b/app/kb/service.py
@@ -1,10 +1,11 @@
 """
-Knowledge base: chunk, embed, store in Chroma; RAG query.
-PRD §5.2.4; docs/01 — Chroma, sentence-transformers for embedding.
+Knowledge base: chunk, embed, store in Chroma; optional graph RAG via LightRAG.
+Hybrid retrieval merges vector similarity + entity-relationship graph.
 """
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 
 from langchain_community.embeddings import HuggingFaceEmbeddings
@@ -14,6 +15,8 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from app.core.config import settings
 from app.models.parser import ParsedDocument
+
+logger = logging.getLogger(__name__)
 
 
 def _get_embeddings():
@@ -25,10 +28,8 @@ def _get_embeddings():
     return _get_embeddings._emb
 
 
-
-
 class KnowledgeBaseService:
-    """Single collection for MVP; persist to CHROMA_PERSIST_DIR."""
+    """Hybrid KB: ChromaDB (vector) + LightRAG (graph) for enriched retrieval."""
 
     CHUNK_SIZE = 1024
     CHUNK_OVERLAP = 128
@@ -53,11 +54,68 @@ class KnowledgeBaseService:
             chunk_overlap=self.CHUNK_OVERLAP,
             separators=["\n\n", "\n", "。", " ", ""],
         )
+        self._graph_rag_enabled = settings.ENABLE_GRAPH_RAG
 
-    def add_document(
+    # ------------------------------------------------------------------
+    # Ingest
+    # ------------------------------------------------------------------
+
+    async def add_document(
         self, parsed: ParsedDocument, document_id: str | None = None
     ) -> str:
-        """Ingest one parsed document into the KB; return document id."""
+        """Ingest one parsed document into vector store + graph RAG."""
+        content = (
+            parsed.content if isinstance(parsed.content, str) else str(parsed.content)
+        )
+        doc_id = document_id or hashlib.sha256(content.encode()).hexdigest()[:16]
+
+        # --- Vector store (Chroma) ---
+        chunks = self._splitter.split_text(content)
+        if chunks:
+            docs = [
+                Document(
+                    page_content=c,
+                    metadata={
+                        "source": parsed.metadata.filename,
+                        "document_id": doc_id,
+                        "type": parsed.metadata.type,
+                        "parser_engine": parsed.metadata.parser_engine,
+                    },
+                )
+                for c in chunks
+            ]
+            self._vectorstore.add_documents(
+                docs, ids=[f"{doc_id}_{i}" for i in range(len(docs))]
+            )
+
+        # --- Graph RAG (LightRAG) ---
+        if self._graph_rag_enabled:
+            await self._insert_to_graph(content, parsed, doc_id)
+
+        return doc_id
+
+    def add_document_sync(
+        self, parsed: ParsedDocument, document_id: str | None = None
+    ) -> str:
+        """Synchronous wrapper for add_document (for non-async callers)."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            # Already in an async context — schedule as task
+            # Fall back to vector-only for sync callers in async context
+            return self._add_document_vector_only(parsed, document_id)
+
+        return asyncio.run(self.add_document(parsed, document_id))
+
+    def _add_document_vector_only(
+        self, parsed: ParsedDocument, document_id: str | None = None
+    ) -> str:
+        """Vector-store-only ingest (no graph RAG)."""
         content = (
             parsed.content if isinstance(parsed.content, str) else str(parsed.content)
         )
@@ -72,6 +130,7 @@ class KnowledgeBaseService:
                     "source": parsed.metadata.filename,
                     "document_id": doc_id,
                     "type": parsed.metadata.type,
+                    "parser_engine": parsed.metadata.parser_engine,
                 },
             )
             for c in chunks
@@ -81,9 +140,113 @@ class KnowledgeBaseService:
         )
         return doc_id
 
-    def query(self, query: str, top_k: int = 5) -> list[Document]:
-        """RAG: return top_k relevant chunks."""
+    async def _insert_to_graph(
+        self, content: str, parsed: ParsedDocument, doc_id: str
+    ) -> None:
+        """Insert document text into LightRAG knowledge graph."""
+        try:
+            from app.kb.graph_rag import get_graph_rag_service
+
+            graph_svc = await get_graph_rag_service()
+            await graph_svc.insert(
+                content,
+                metadata={
+                    "source": parsed.metadata.filename,
+                    "document_id": doc_id,
+                    "type": parsed.metadata.type,
+                },
+            )
+        except Exception as e:
+            logger.warning("Graph RAG insert failed (non-blocking): %s", e)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    async def query(self, query: str, top_k: int = 5) -> list[Document]:
+        """
+        Hybrid RAG query: merge vector similarity + graph retrieval.
+
+        When graph RAG is disabled, falls back to vector-only (original behavior).
+        """
+        # Vector search (always)
+        vector_docs = self._vectorstore.similarity_search(query, k=top_k)
+
+        # Graph search (when enabled)
+        if self._graph_rag_enabled:
+            graph_docs = await self._query_graph(query, top_k=top_k)
+            return self._merge_results(vector_docs, graph_docs, top_k)
+
+        return vector_docs
+
+    def query_sync(self, query: str, top_k: int = 5) -> list[Document]:
+        """Synchronous vector-only query (backward compatible)."""
         return self._vectorstore.similarity_search(query, k=top_k)
+
+    async def _query_graph(self, query: str, top_k: int = 5) -> list[Document]:
+        """Query LightRAG and convert results to Document objects."""
+        try:
+            from app.kb.graph_rag import get_graph_rag_service
+
+            graph_svc = await get_graph_rag_service()
+            raw_chunks = await graph_svc.query(query, top_k=top_k)
+
+            return [
+                Document(
+                    page_content=chunk["content"],
+                    metadata=chunk.get("metadata", {}),
+                )
+                for chunk in raw_chunks
+            ]
+        except Exception as e:
+            logger.warning("Graph RAG query failed (non-blocking): %s", e)
+            return []
+
+    def _merge_results(
+        self,
+        vector_docs: list[Document],
+        graph_docs: list[Document],
+        top_k: int,
+    ) -> list[Document]:
+        """
+        Merge and deduplicate results from vector and graph retrieval.
+
+        Strategy: interleave vector and graph results, deduplicate by content,
+        prefer vector results for duplicates (they have richer metadata).
+        """
+        seen_content: set[str] = set()
+        merged: list[Document] = []
+
+        # Interleave: vector first for each position, then graph
+        v_iter = iter(vector_docs)
+        g_iter = iter(graph_docs)
+
+        while len(merged) < top_k * 2:  # allow up to 2x for richer context
+            # Take from vector
+            v_doc = next(v_iter, None)
+            if v_doc:
+                key = v_doc.page_content[:200]
+                if key not in seen_content:
+                    seen_content.add(key)
+                    merged.append(v_doc)
+
+            # Take from graph
+            g_doc = next(g_iter, None)
+            if g_doc:
+                key = g_doc.page_content[:200]
+                if key not in seen_content:
+                    seen_content.add(key)
+                    merged.append(g_doc)
+
+            # Both exhausted
+            if v_doc is None and g_doc is None:
+                break
+
+        return merged
+
+    # ------------------------------------------------------------------
+    # History
+    # ------------------------------------------------------------------
 
     def add_history_response(
         self,
@@ -122,7 +285,11 @@ class KnowledgeBaseService:
     def query_history_responses(self, query: str, top_k: int = 3) -> list[Document]:
         return self._history_store.similarity_search(query, k=top_k)
 
-    def reindex_directory(self, directory: str) -> dict:
+    # ------------------------------------------------------------------
+    # Reindex
+    # ------------------------------------------------------------------
+
+    async def reindex_directory(self, directory: str) -> dict:
         from app.parser import parse_file
 
         root = Path(directory)
@@ -142,7 +309,34 @@ class KnowledgeBaseService:
                 continue
             try:
                 parsed = parse_file(path.read_bytes(), path.name)
-                self.add_document(parsed)
+                await self.add_document(parsed)
+                indexed += 1
+            except Exception as e:
+                errors.append(f"{path.name}: {e!s}")
+        return {"directory": str(root), "indexed": indexed, "errors": errors}
+
+    def reindex_directory_sync(self, directory: str) -> dict:
+        """Synchronous reindex (vector-only, for non-async callers)."""
+        from app.parser import parse_file
+
+        root = Path(directory)
+        if not root.exists():
+            return {
+                "directory": directory,
+                "indexed": 0,
+                "errors": ["directory_not_found"],
+            }
+        indexed = 0
+        errors: list[str] = []
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            suffix = path.suffix.lower()
+            if suffix not in {".pdf", ".docx", ".xlsx", ".pptx", ".txt", ".md"}:
+                continue
+            try:
+                parsed = parse_file(path.read_bytes(), path.name)
+                self._add_document_vector_only(parsed)
                 indexed += 1
             except Exception as e:
                 errors.append(f"{path.name}: {e!s}")

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
 async def _kb_auto_sync_loop():
     while True:
         kb_service = KnowledgeBaseService()
-        kb_service.reindex_directory(settings.KB_AUTO_SYNC_DIR)
+        await kb_service.reindex_directory(settings.KB_AUTO_SYNC_DIR)
         await asyncio.sleep(settings.KB_AUTO_SYNC_INTERVAL_SECONDS)
 
 

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp import FastMCP
 # Use absolute imports from app package
 from app.agent.orchestrator import run_assessment
 from app.kb.service import KnowledgeBaseService
-from app.models.parser import ParsedDocument, ParsedDocumentMetadata
+from app.parser import parse_file
 
 # Initialize MCP Server
 mcp = FastMCP("DocSentinel")
@@ -38,28 +38,13 @@ async def assess_document(file_path: str, scenario_id: str = "default") -> str:
     if not os.path.exists(file_path):
         return json.dumps({"error": f"File not found: {file_path}"})
 
-    # Simulate file reading and parsing
-    # In a real scenario, we would use the actual ParserService to parse the
-    # file content. For now, let's just read the text content if it's a text
-    # file, or use a placeholder. Since we can't easily reuse the full parser
-    # stack without UploadFile dependency, let's read the file as raw text for
-    # simplicity in this MVP MCP tool.
-
-    content = ""
+    # Use the full parser pipeline (Docling → Markdown for PDF/Word/Excel/PPT)
     try:
-        with open(file_path, errors="ignore") as f:
-            content = f.read()
+        with open(file_path, "rb") as f:
+            raw_content = f.read()
+        parsed_doc = parse_file(raw_content, os.path.basename(file_path))
     except Exception as e:
-        return json.dumps({"error": f"Failed to read file: {str(e)}"})
-
-    # Create a parsed document object
-    parsed_doc = ParsedDocument(
-        content=content,
-        metadata=ParsedDocumentMetadata(
-            filename=os.path.basename(file_path),
-            type="text/plain",  # Simplified
-        ),
-    )
+        return json.dumps({"error": f"Failed to parse file: {str(e)}"})
 
     try:
         # Use a random UUID for task_id since we are running standalone

--- a/app/models/parser.py
+++ b/app/models/parser.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 class ParsedDocumentMetadata(BaseModel):
     filename: str
     type: Literal["pdf", "docx", "xlsx", "pptx", "txt", "md"]
+    parser_engine: Literal["docling", "legacy"] = "legacy"
     upload_time: datetime = Field(default_factory=datetime.utcnow)
     scenario_id: str | None = None
     file_hash: str | None = None

--- a/app/parser/service.py
+++ b/app/parser/service.py
@@ -1,16 +1,71 @@
 """
-Document parsing: multi-format to LLM-readable (Markdown/JSON).
-PRD §5.2.5; docs/01 — PyMuPDF, python-docx, openpyxl, python-pptx.
+Document parsing: multi-format to structured Markdown/JSON.
+Primary engine: Docling (preserves tables, headings, OCR for scanned PDFs).
+Fallback: legacy parsers (PyMuPDF, python-docx, openpyxl, python-pptx).
 """
 
 import io
+import logging
+import tempfile
 from pathlib import Path
 
+from app.core.config import settings
 from app.models.parser import ParsedDocument, ParsedDocumentMetadata
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Docling-based parser (primary)
+# ---------------------------------------------------------------------------
+
+
+def _parse_with_docling(content: bytes, filename: str) -> ParsedDocument:
+    """
+    Convert document to structured Markdown using Docling.
+    Supports PDF, DOCX, XLSX, PPTX with table/heading preservation.
+    """
+    from docling.document_converter import DocumentConverter
+
+    suffix = Path(filename).suffix.lower()
+
+    # Docling requires a file path — write to temp file
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        converter = DocumentConverter()
+        result = converter.convert(tmp_path)
+
+        # Export structured Markdown (preserves tables, headings, lists)
+        markdown_content = result.document.export_to_markdown()
+
+        # Export JSON structure for metadata/raw access
+        raw_structure = result.document.export_to_dict()
+
+        if not markdown_content or not markdown_content.strip():
+            markdown_content = "(no text extracted by Docling)"
+
+        return ParsedDocument(
+            content=markdown_content.strip(),
+            raw_structure=raw_structure,
+            metadata=ParsedDocumentMetadata(
+                filename=_safe_filename(filename),
+                type=suffix.lstrip("."),
+                parser_engine="docling",
+            ),
+        )
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Legacy parsers (fallback)
+# ---------------------------------------------------------------------------
 
 
 def _safe_filename(name: str) -> str:
-    """Sanitise filename for metadata (PRD §7.2 APP-01)."""
+    """Sanitise filename for metadata."""
     return Path(name).name[:255] if name else "unknown"
 
 
@@ -26,7 +81,7 @@ def _parse_pdf(content: bytes, filename: str) -> ParsedDocument:
     return ParsedDocument(
         content=text,
         metadata=ParsedDocumentMetadata(
-            filename=_safe_filename(filename), type="pdf"
+            filename=_safe_filename(filename), type="pdf", parser_engine="legacy"
         ),
     )
 
@@ -43,8 +98,7 @@ def _parse_docx(content: bytes, filename: str) -> ParsedDocument:
     return ParsedDocument(
         content=text,
         metadata=ParsedDocumentMetadata(
-            filename=_safe_filename(filename),
-            type="docx",
+            filename=_safe_filename(filename), type="docx", parser_engine="legacy"
         ),
     )
 
@@ -63,8 +117,7 @@ def _parse_xlsx(content: bytes, filename: str) -> ParsedDocument:
     return ParsedDocument(
         content=text,
         metadata=ParsedDocumentMetadata(
-            filename=_safe_filename(filename),
-            type="xlsx",
+            filename=_safe_filename(filename), type="xlsx", parser_engine="legacy"
         ),
     )
 
@@ -83,8 +136,7 @@ def _parse_pptx(content: bytes, filename: str) -> ParsedDocument:
     return ParsedDocument(
         content=text,
         metadata=ParsedDocumentMetadata(
-            filename=_safe_filename(filename),
-            type="pptx",
+            filename=_safe_filename(filename), type="pptx", parser_engine="legacy"
         ),
     )
 
@@ -97,14 +149,23 @@ def _parse_plain(content: bytes, filename: str, content_type: str) -> ParsedDocu
     return ParsedDocument(
         content=text.strip() or "(empty)",
         metadata=ParsedDocumentMetadata(
-            filename=_safe_filename(filename), type=content_type
+            filename=_safe_filename(filename),
+            type=content_type,
+            parser_engine="legacy",
         ),
     )
 
 
-# Allowed extensions and MIME (PRD §7.2 APP-01)
+# ---------------------------------------------------------------------------
+# Extension whitelist and dispatch
+# ---------------------------------------------------------------------------
+
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".txt", ".md"}
-EXTENSION_TO_PARSER = {
+
+# Extensions that Docling can handle natively
+_DOCLING_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx"}
+
+_LEGACY_PARSERS = {
     ".pdf": _parse_pdf,
     ".docx": _parse_docx,
     ".xlsx": _parse_xlsx,
@@ -117,7 +178,13 @@ EXTENSION_TO_PARSER = {
 def parse_file(content: bytes, filename: str) -> ParsedDocument:
     """
     Parse a single file into ParsedDocument.
-    Raises ValueError for unsupported type or parse error.
+
+    Engine selection (via PARSER_ENGINE config):
+      - "auto": Try Docling first for supported formats, fall back to legacy.
+      - "docling": Use Docling only (raises on failure).
+      - "legacy": Use legacy parsers only (original behavior).
+
+    Raises ValueError for unsupported file types.
     """
     path = Path(filename)
     suffix = path.suffix.lower()
@@ -125,5 +192,27 @@ def parse_file(content: bytes, filename: str) -> ParsedDocument:
         raise ValueError(
             f"Unsupported file type: {suffix}. Allowed: {sorted(ALLOWED_EXTENSIONS)}"
         )
-    parser_fn = EXTENSION_TO_PARSER[suffix]
-    return parser_fn(content, filename)
+
+    engine = settings.PARSER_ENGINE
+
+    # Plain text/markdown always use legacy (no benefit from Docling)
+    if suffix in {".txt", ".md"}:
+        return _LEGACY_PARSERS[suffix](content, filename)
+
+    # Docling-capable formats
+    if engine == "docling":
+        return _parse_with_docling(content, filename)
+
+    if engine == "auto" and suffix in _DOCLING_EXTENSIONS:
+        try:
+            return _parse_with_docling(content, filename)
+        except Exception as e:
+            logger.warning(
+                "Docling failed for %s, falling back to legacy parser: %s",
+                filename,
+                e,
+            )
+            return _LEGACY_PARSERS[suffix](content, filename)
+
+    # engine == "legacy" or fallback
+    return _LEGACY_PARSERS[suffix](content, filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
     "reportlab",
     "aiofiles",
     "moviepy",
-    "mcp"
+    "mcp",
+    "docling>=2.0.0",
+    "lightrag-hku>=1.0.0"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,11 +22,17 @@ langchain-core>=0.1.0
 chromadb>=0.4.22
 sentence-transformers>=2.2.0
 
-# Document parsing
+# Document parsing (legacy fallback)
 pymupdf>=1.23.0
 python-docx>=1.1.0
 openpyxl>=3.1.0
 python-pptx>=0.6.21
+
+# Document-to-Markdown conversion (primary)
+docling>=2.0.0
+
+# Graph-based RAG
+lightrag-hku>=1.0.0
 
 # HTTP & async
 httpx>=0.26.0

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -1,0 +1,158 @@
+"""Tests for graph RAG service and hybrid KB retrieval."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.kb.service import KnowledgeBaseService
+from app.models.parser import ParsedDocument, ParsedDocumentMetadata
+
+
+@pytest.fixture
+def parsed_doc():
+    return ParsedDocument(
+        content="Password must be 12+ chars per ISO 27001.",
+        metadata=ParsedDocumentMetadata(
+            filename="policy.md", type="md", parser_engine="legacy"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_document_inserts_to_graph_when_enabled(parsed_doc):
+    """When ENABLE_GRAPH_RAG=True, add_document also inserts into graph."""
+    with patch("app.kb.service.settings") as mock_settings:
+        mock_settings.CHROMA_PERSIST_DIR = "/tmp/test_chroma"
+        mock_settings.EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+        mock_settings.ENABLE_GRAPH_RAG = True
+
+        with patch("app.kb.service.Chroma"):
+            with patch("app.kb.service._get_embeddings"):
+                kb = KnowledgeBaseService()
+
+                with patch.object(
+                    kb, "_insert_to_graph", new_callable=AsyncMock
+                ) as mock_graph:
+                    await kb.add_document(parsed_doc)
+                    mock_graph.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_document_skips_graph_when_disabled(parsed_doc):
+    """When ENABLE_GRAPH_RAG=False, graph insert is skipped."""
+    with patch("app.kb.service.settings") as mock_settings:
+        mock_settings.CHROMA_PERSIST_DIR = "/tmp/test_chroma"
+        mock_settings.EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+        mock_settings.ENABLE_GRAPH_RAG = False
+
+        with patch("app.kb.service.Chroma"):
+            with patch("app.kb.service._get_embeddings"):
+                kb = KnowledgeBaseService()
+
+                with patch.object(
+                    kb, "_insert_to_graph", new_callable=AsyncMock
+                ) as mock_graph:
+                    await kb.add_document(parsed_doc)
+                    mock_graph.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_query_hybrid_merges_vector_and_graph():
+    """Hybrid query returns merged results from vector + graph."""
+    with patch("app.kb.service.settings") as mock_settings:
+        mock_settings.CHROMA_PERSIST_DIR = "/tmp/test_chroma"
+        mock_settings.EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+        mock_settings.ENABLE_GRAPH_RAG = True
+
+        with patch("app.kb.service.Chroma") as mock_chroma_cls:
+            with patch("app.kb.service._get_embeddings"):
+                # Mock vector store results
+                mock_vector_doc = MagicMock()
+                mock_vector_doc.page_content = "Vector result about encryption"
+                mock_vector_doc.metadata = {
+                    "source": "policy.pdf",
+                    "source_type": "vector",
+                }
+
+                mock_chroma_inst = MagicMock()
+                mock_chroma_inst.similarity_search.return_value = [mock_vector_doc]
+                mock_chroma_cls.return_value = mock_chroma_inst
+
+                kb = KnowledgeBaseService()
+
+                # Mock graph results
+                mock_graph_doc = MagicMock()
+                mock_graph_doc.page_content = "Graph: encryption → AES-256"
+                mock_graph_doc.metadata = {
+                    "source": "graph_rag",
+                    "source_type": "graph",
+                }
+
+                with patch.object(
+                    kb,
+                    "_query_graph",
+                    new_callable=AsyncMock,
+                    return_value=[mock_graph_doc],
+                ):
+                    results = await kb.query("encryption standards", top_k=5)
+
+                    # Should have both vector and graph results
+                    assert len(results) == 2
+                    contents = [r.page_content for r in results]
+                    assert any("Vector" in c for c in contents)
+                    assert any("Graph" in c for c in contents)
+
+
+@pytest.mark.asyncio
+async def test_query_vector_only_when_graph_disabled():
+    """When graph RAG is disabled, query returns vector-only results."""
+    with patch("app.kb.service.settings") as mock_settings:
+        mock_settings.CHROMA_PERSIST_DIR = "/tmp/test_chroma"
+        mock_settings.EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+        mock_settings.ENABLE_GRAPH_RAG = False
+
+        with patch("app.kb.service.Chroma") as mock_chroma_cls:
+            with patch("app.kb.service._get_embeddings"):
+                mock_doc = MagicMock()
+                mock_doc.page_content = "Vector only"
+                mock_doc.metadata = {}
+
+                mock_inst = MagicMock()
+                mock_inst.similarity_search.return_value = [mock_doc]
+                mock_chroma_cls.return_value = mock_inst
+
+                kb = KnowledgeBaseService()
+                results = await kb.query("test", top_k=5)
+
+                assert len(results) == 1
+                assert results[0].page_content == "Vector only"
+
+
+def test_merge_deduplicates_by_content():
+    """Merge results deduplicates documents with same content prefix."""
+    with patch("app.kb.service.settings") as mock_settings:
+        mock_settings.CHROMA_PERSIST_DIR = "/tmp/test_chroma"
+        mock_settings.EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+        mock_settings.ENABLE_GRAPH_RAG = True
+
+        with patch("app.kb.service.Chroma"):
+            with patch("app.kb.service._get_embeddings"):
+                kb = KnowledgeBaseService()
+
+                # Create two docs with same content
+                doc1 = MagicMock()
+                doc1.page_content = "Same content about access control"
+                doc1.metadata = {"source_type": "vector"}
+
+                doc2 = MagicMock()
+                doc2.page_content = "Same content about access control"
+                doc2.metadata = {"source_type": "graph"}
+
+                doc3 = MagicMock()
+                doc3.page_content = "Different content about encryption"
+                doc3.metadata = {"source_type": "graph"}
+
+                merged = kb._merge_results([doc1], [doc2, doc3], top_k=5)
+
+                # doc2 should be deduplicated (same content prefix as doc1)
+                assert len(merged) == 2

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -36,7 +36,7 @@ async def test_orchestrator_uses_skill_prompt():
             # Mock KB (to avoid actual DB calls)
             with patch("app.agent.orchestrator.KnowledgeBaseService") as mock_kb_cls:
                 mock_kb = MagicMock()
-                mock_kb.query.return_value = []
+                mock_kb.query = AsyncMock(return_value=[])
                 mock_kb.query_history_responses.return_value = []
                 mock_kb_cls.return_value = mock_kb
 

--- a/tests/test_parser_docling.py
+++ b/tests/test_parser_docling.py
@@ -1,0 +1,101 @@
+"""Tests for Docling-enhanced parser."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.parser import parse_file
+from app.parser.service import ALLOWED_EXTENSIONS
+
+
+def test_txt_always_uses_legacy():
+    """Plain text files skip Docling regardless of PARSER_ENGINE."""
+    with patch("app.parser.service.settings") as mock_settings:
+        mock_settings.PARSER_ENGINE = "auto"
+        doc = parse_file(b"Hello world", "readme.txt")
+        assert doc.metadata.parser_engine == "legacy"
+        assert doc.metadata.type == "txt"
+        assert doc.content == "Hello world"
+
+
+def test_md_always_uses_legacy():
+    """Markdown files skip Docling regardless of PARSER_ENGINE."""
+    with patch("app.parser.service.settings") as mock_settings:
+        mock_settings.PARSER_ENGINE = "docling"
+        doc = parse_file(b"# Heading\n\nBody", "policy.md")
+        assert doc.metadata.parser_engine == "legacy"
+        assert doc.metadata.type == "md"
+
+
+def test_legacy_engine_skips_docling():
+    """When PARSER_ENGINE=legacy, Docling is never called."""
+    with patch("app.parser.service.settings") as mock_settings:
+        mock_settings.PARSER_ENGINE = "legacy"
+        with patch("app.parser.service._parse_with_docling") as mock_docling:
+            doc = parse_file(b"Simple text content.", "sample.txt")
+            mock_docling.assert_not_called()
+            assert doc.metadata.parser_engine == "legacy"
+
+
+def test_auto_engine_falls_back_on_docling_failure():
+    """When PARSER_ENGINE=auto and Docling fails, legacy parser is used."""
+    from app.parser.service import _LEGACY_PARSERS
+
+    mock_pdf = MagicMock(
+        return_value=MagicMock(
+            content="fallback",
+            metadata=MagicMock(parser_engine="legacy"),
+        )
+    )
+    original = _LEGACY_PARSERS[".pdf"]
+    _LEGACY_PARSERS[".pdf"] = mock_pdf
+    try:
+        with patch("app.parser.service.settings") as mock_settings:
+            mock_settings.PARSER_ENGINE = "auto"
+            with patch(
+                "app.parser.service._parse_with_docling",
+                side_effect=RuntimeError("Docling unavailable"),
+            ):
+                parse_file(b"%PDF-1.4 fake", "report.pdf")
+                mock_pdf.assert_called_once()
+    finally:
+        _LEGACY_PARSERS[".pdf"] = original
+
+
+def test_docling_engine_raises_on_failure():
+    """When PARSER_ENGINE=docling, failure raises (no fallback)."""
+    with patch("app.parser.service.settings") as mock_settings:
+        mock_settings.PARSER_ENGINE = "docling"
+        with patch(
+            "app.parser.service._parse_with_docling",
+            side_effect=RuntimeError("Docling crash"),
+        ):
+            with pytest.raises(RuntimeError, match="Docling crash"):
+                parse_file(b"%PDF fake", "report.pdf")
+
+
+def test_auto_engine_calls_docling_for_pdf():
+    """When PARSER_ENGINE=auto, Docling is attempted for PDF files."""
+    with patch("app.parser.service.settings") as mock_settings:
+        mock_settings.PARSER_ENGINE = "auto"
+        mock_result = MagicMock(
+            content="# Converted\nTable data",
+            metadata=MagicMock(parser_engine="docling", type="pdf"),
+        )
+        with patch(
+            "app.parser.service._parse_with_docling", return_value=mock_result
+        ) as mock_docling:
+            parse_file(b"%PDF-1.4 data", "report.pdf")
+            mock_docling.assert_called_once()
+
+
+def test_allowed_extensions_unchanged():
+    """ALLOWED_EXTENSIONS still includes all expected types."""
+    expected = {".pdf", ".docx", ".xlsx", ".pptx", ".txt", ".md"}
+    assert ALLOWED_EXTENSIONS == expected
+
+
+def test_unsupported_extension_still_raises():
+    """Unsupported file type raises ValueError regardless of engine."""
+    with pytest.raises(ValueError, match="Unsupported"):
+        parse_file(b"content", "file.xyz")


### PR DESCRIPTION
## Summary

Implements hybrid RAG combining vector similarity (ChromaDB) with graph-based entity-relationship retrieval (LightRAG). Adds Docling for superior document-to-Markdown conversion with table/heading preservation.

## Key Changes

### Document Parsing (`app/parser/service.py`)
- **Primary**: Docling engine converts PDF/DOCX/XLSX/PPTX → structured Markdown (preserves tables, OCR)
- **Fallback**: Legacy parsers (PyMuPDF, python-docx, openpyxl, python-pptx) when Docling unavailable
- **Config**: `PARSER_ENGINE` setting: `"auto"` (Docling→fallback), `"docling"` (Docling only), `"legacy"` (original)
- **Metadata**: `parser_engine` field tracks which parser was used

### Knowledge Base Service (`app/kb/service.py`)
- **Hybrid Ingestion**: `add_document()` inserts to both ChromaDB (vector) and LightRAG (graph) when enabled
- **Hybrid Query**: `query()` merges vector + graph results with deduplication; interleaves results prioritizing vector metadata
- **Async/Sync**: Async methods for production (`add_document`, `query`, `reindex_directory`); sync wrappers for backward compatibility
- **Configuration**: `ENABLE_GRAPH_RAG` controls graph insertion; graph disabled = original vector-only behavior

### Graph RAG Service (`app/kb/graph_rag.py`)
- **LightRAG Integration**: Lazy singleton service with async initialization
- **Query Modes**: Supports `"naive"`, `"local"`, `"global"`, `"hybrid"` (configurable)
- **Adapters**: LLM and embedding function adapters to integrate with project's LLM provider
- **Metadata Tagging**: Graph results marked with `source_type="graph"`, `graph_mode` for downstream formatting

### Agent Orchestrator (`app/agent/orchestrator.py`)
- **Async Query**: `_policy_and_history_agent()` now async; awaits KB hybrid query
- **Chunk Formatting**: Distinguishes graph results (entity/community summaries) from vector results in formatted output

### Configuration (`app/core/config.py`, `.env.example`)
- `PARSER_ENGINE`: Parser selection ("auto", "docling", "legacy")
- `ENABLE_GRAPH_RAG`: Toggle graph retrieval (default: true)
- `LIGHTRAG_WORKING_DIR`: Graph storage location
- `GRAPH_RAG_QUERY_MODE`: Retrieval strategy ("naive", "local", "global", "hybrid")

### Dependencies (`pyproject.toml`, `requirements.txt`)
- Added: `docling>=2.0.0` (primary parser), `lightrag-hku>=1.0.0` (graph RAG)

### Tests
- **`test_graph_rag.py`**: Hybrid query merging, graph insertion gating, deduplication
- **`test_parser_docling.py`**: Parser engine selection, fallback logic, format handling
- **`test_orchestrator.py`**: Updated mock to handle async KB query

## Benefits

- **Better Document Fidelity**: Docling preserves tables, structure, OCR for scanned PDFs
- **Entity-Aware Retrieval**: Graph RAG finds connections (e.g., "ISO 27001" → "access control" → "password policy")
- **Graceful Degradation**: Docling failures auto-fallback to legacy; graph RAG optional
- **Backward Compatible**: Sync wrappers preserve existing API; graph disabled = original behavior
