### PR TITLE
refactor: improve assessment pipeline correctness (P0/P1/P2)

### DIFF
--- a/app/agent/orchestrator.py
+++ b/app/agent/orchestrator.py
@@ -25,6 +25,11 @@ from app.models.parser import ParsedDocument
 
 logger = logging.getLogger(__name__)
 
+# Documents longer than this threshold are split for map-reduce assessment.
+_LARGE_DOC_THRESHOLD = 12_000
+_DOC_CHUNK_SIZE = 10_000
+_DOC_CHUNK_OVERLAP = 500
+
 
 def _truncate_at_boundary(text: str, max_chars: int) -> str:
     """Truncate text at the nearest paragraph or sentence boundary."""
@@ -38,6 +43,75 @@ def _truncate_at_boundary(text: str, max_chars: int) -> str:
     return truncated
 
 
+def _extract_query_seed(
+    full_text: str,
+    skill_focus: list[str] | None = None,
+    max_chars: int = 2000,
+) -> str:
+    """Select the most security-relevant paragraphs as a KB query seed.
+
+    Scores each paragraph by occurrence count of skill focus terms, then
+    greedily packs the highest-scoring paragraphs up to max_chars.  Falls
+    back to the document head when no focus terms are provided.
+    """
+    if len(full_text) <= max_chars:
+        return full_text
+
+    focus_terms = {
+        t.lower()
+        for term in (skill_focus or [])
+        for t in term.split()
+        if len(t) > 2
+    }
+
+    if not focus_terms:
+        return full_text[:max_chars]
+
+    paragraphs = [p.strip() for p in full_text.split("\n\n") if p.strip()]
+    if not paragraphs:
+        return full_text[:max_chars]
+
+    scored = sorted(
+        paragraphs,
+        key=lambda p: sum(1 for t in focus_terms if t in p.lower()),
+        reverse=True,
+    )
+
+    selected: list[str] = []
+    total = 0
+    for p in scored:
+        cost = len(p) + 2  # account for "\n\n" separator
+        if total + cost > max_chars:
+            break
+        selected.append(p)
+        total += cost
+
+    return "\n\n".join(selected) if selected else full_text[:max_chars]
+
+
+def _split_text_with_overlap(text: str, chunk_size: int, overlap: int) -> list[str]:
+    """Split text into overlapping chunks, breaking at paragraph boundaries."""
+    if len(text) <= chunk_size:
+        return [text]
+
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        end = start + chunk_size
+        if end >= len(text):
+            chunks.append(text[start:])
+            break
+        # Prefer to break at a paragraph boundary in the latter half of the window.
+        boundary = text.rfind("\n\n", start + chunk_size // 2, end)
+        if boundary == -1:
+            boundary = text.rfind("\n", start + chunk_size // 2, end)
+        if boundary == -1:
+            boundary = end
+        chunks.append(text[start:boundary])
+        start = boundary - overlap
+    return chunks
+
+
 async def run_assessment(
     task_id: UUID,
     parsed_documents: list[ParsedDocument],
@@ -48,31 +122,37 @@ async def run_assessment(
     skill_service = get_skill_service()
     skill = skill_service.get_skill(skill_id) if skill_id else None
     if not skill:
+        logger.warning(
+            "No skill_id provided or skill not found; defaulting to first built-in skill."
+        )
         skill = skill_service.list_skills()[0]
 
-    doc_context = _build_document_context(parsed_documents)
+    doc_context = _build_document_context(parsed_documents, skill_focus=skill.risk_focus)
 
-    # Steps 1 (KB lookup) and 2 (evidence scan) are independent — run in parallel.
-    # _policy_and_history_agent is async (graph RAG); _evidence_agent is sync.
-    loop = asyncio.get_running_loop()
+    # KB lookup and evidence extraction are independent — run in parallel.
     policy_future = _policy_and_history_agent(
         doc_context["query_seed"], skill_focus=skill.risk_focus,
     )
-    evidence_future = loop.run_in_executor(
-        None, _evidence_agent, parsed_documents, skill.risk_focus,
-    )
+    evidence_future = _evidence_agent(parsed_documents, skill.risk_focus)
     (policy_chunks, history_chunks), evidence_context = await asyncio.gather(
         policy_future, evidence_future,
     )
 
-    draft_raw = await _drafter_agent(
-        doc_context["full_text"], policy_chunks, history_chunks, skill=skill,
-    )
+    full_text = doc_context["full_text"]
+    if len(full_text) > _LARGE_DOC_THRESHOLD:
+        draft_raw = await _draft_large_document(
+            full_text, policy_chunks, history_chunks, skill=skill,
+        )
+    else:
+        draft_raw = await _drafter_agent(
+            full_text, policy_chunks, history_chunks, skill=skill,
+        )
 
     reviewed_raw = await _reviewer_agent(
         draft_raw, evidence_context, policy_chunks, history_chunks, skill=skill,
     )
 
+    chunk_lookup = _build_chunk_lookup(policy_chunks, history_chunks)
     return _parse_llm_output_to_report(
         raw=reviewed_raw,
         task_id=task_id,
@@ -80,17 +160,24 @@ async def run_assessment(
         history_chunks=history_chunks,
         scenario_id=scenario_id,
         project_id=project_id,
+        chunk_lookup=chunk_lookup,
     )
 
 
-def _build_document_context(parsed_documents: list[ParsedDocument]) -> dict:
-    """Combine parsed documents into a single text block."""
+def _build_document_context(
+    parsed_documents: list[ParsedDocument],
+    skill_focus: list[str] | None = None,
+) -> dict:
+    """Combine parsed documents and build a semantically relevant KB query seed."""
     doc_texts: list[str] = []
     for d in parsed_documents:
         c = d.content if isinstance(d.content, str) else str(d.content)
         doc_texts.append(f"[{d.metadata.filename}]\n{c}")
     combined_input = "\n\n---\n\n".join(doc_texts)
-    return {"full_text": combined_input, "query_seed": combined_input[:2000]}
+    return {
+        "full_text": combined_input,
+        "query_seed": _extract_query_seed(combined_input, skill_focus),
+    }
 
 
 async def _policy_and_history_agent(
@@ -115,10 +202,48 @@ async def _policy_and_history_agent(
     return policy_chunks, history_chunks
 
 
-def _evidence_agent(
+async def _evidence_agent(
     parsed_documents: list[ParsedDocument],
     skill_focus: list[str] | None = None,
 ) -> str:
+    """Extract security-relevant evidence via LLM, with a keyword-scan fallback."""
+    focus_str = ", ".join(skill_focus) if skill_focus else "general security risks"
+
+    doc_parts: list[str] = []
+    for d in parsed_documents:
+        content = d.content if isinstance(d.content, str) else str(d.content)
+        doc_parts.append(
+            f"[{d.metadata.filename}]\n{_truncate_at_boundary(content, 6000)}"
+        )
+    combined = "\n\n---\n\n".join(doc_parts)
+
+    system_prompt = (
+        "You are a security evidence extractor. "
+        "Extract verbatim lines or short passages that directly support or contradict "
+        "the given focus areas. Format each line as: filename#Ln: <exact quote>. "
+        "Return only evidence lines, one per line, maximum 30 lines."
+    )
+    user_prompt = (
+        f"Focus areas: {focus_str}\n\n"
+        f"Document content:\n{_truncate_at_boundary(combined, 8000)}\n\n"
+        "Extract relevant evidence lines:"
+    )
+
+    try:
+        result = await invoke_llm(system_prompt, user_prompt)
+        if result.strip():
+            return result.strip()
+    except Exception as e:
+        logger.warning("LLM evidence extraction failed, falling back to keyword scan: %s", e)
+
+    return _evidence_agent_keyword_fallback(parsed_documents, skill_focus)
+
+
+def _evidence_agent_keyword_fallback(
+    parsed_documents: list[ParsedDocument],
+    skill_focus: list[str] | None = None,
+) -> str:
+    """Keyword-based evidence extraction used when LLM extraction is unavailable."""
     evidence_lines: list[str] = []
 
     keywords = ["password", "encrypt", "access", "token", "risk", "vulnerability"]
@@ -173,6 +298,52 @@ async def _drafter_agent(
     return await invoke_llm(base_prompt, user_prompt)
 
 
+async def _draft_large_document(
+    full_text: str,
+    policy_chunks: list,
+    history_chunks: list,
+    skill: object | None = None,
+) -> str:
+    """Map-reduce drafting for documents that exceed the single-pass context limit."""
+    sections = _split_text_with_overlap(full_text, _DOC_CHUNK_SIZE, _DOC_CHUNK_OVERLAP)
+    logger.info(
+        "Document exceeds %d chars; running map-reduce over %d sections.",
+        _LARGE_DOC_THRESHOLD,
+        len(sections),
+    )
+    section_drafts = await asyncio.gather(*[
+        _drafter_agent(section, policy_chunks, history_chunks, skill=skill)
+        for section in sections
+    ])
+    return await _merge_drafts(list(section_drafts), skill=skill)
+
+
+async def _merge_drafts(drafts: list[str], skill: object | None = None) -> str:
+    """Consolidate section drafts into one unified assessment JSON."""
+    drafts_text = "\n\n---\n\n".join(
+        f"## Section {i + 1}\n{d}" for i, d in enumerate(drafts)
+    )
+
+    skill_info = ""
+    if skill:
+        frameworks = ", ".join(getattr(skill, "compliance_frameworks", []))
+        skill_info = f"Apply {frameworks} frameworks. "
+
+    system_prompt = (
+        "You are MergeAgent. Consolidate multiple security assessment drafts from "
+        "different sections of the same document into one unified assessment. "
+        f"{skill_info}"
+        "Deduplicate findings, keep the highest-severity version of duplicates, "
+        "and merge remediations. "
+        "Output JSON with keys: summary, risk_items, compliance_gaps, remediations."
+    )
+    user_prompt = (
+        f"{_truncate_at_boundary(drafts_text, 14000)}\n\n"
+        "Merge into one unified JSON assessment, deduplicating findings across sections."
+    )
+    return await invoke_llm(system_prompt, user_prompt)
+
+
 async def _reviewer_agent(
     draft_raw: str,
     evidence_context: str,
@@ -183,10 +354,24 @@ async def _reviewer_agent(
     policy_context = _format_chunks_with_ids(policy_chunks, prefix="POL")
     history_context = _format_chunks_with_ids(history_chunks, prefix="HIS")
 
+    chunk_ids = (
+        ", ".join(
+            [f"POL-{i + 1}" for i in range(len(policy_chunks))]
+            + [f"HIS-{i + 1}" for i in range(len(history_chunks))]
+        )
+        or "none"
+    )
+
     base_prompt = (
         "You are ReviewerAgent. Validate and improve the draft for consistency and "
-        "hallucination resistance. Output JSON only with keys: summary, confidence, "
-        "risk_items, compliance_gaps, remediations, sources."
+        "hallucination resistance. "
+        "Output JSON only with keys: summary, confidence, risk_items, "
+        "compliance_gaps, remediations, sources. "
+        f"Available chunk IDs: {chunk_ids}. "
+        "In the `sources` array each entry MUST have: "
+        '`"chunk_id"` (one of the available IDs above) and '
+        '`"quote"` (verbatim excerpt from that chunk supporting a finding). '
+        "Only include chunks you actually used."
     )
 
     if skill:
@@ -195,7 +380,12 @@ async def _reviewer_agent(
             f"Validate the draft against {', '.join(skill.compliance_frameworks)}. "
             "Ensure findings match the persona's focus. "
             "Output JSON only with keys: summary, confidence, risk_items, "
-            "compliance_gaps, remediations, sources."
+            "compliance_gaps, remediations, sources. "
+            f"Available chunk IDs: {chunk_ids}. "
+            "In the `sources` array each entry MUST have: "
+            '`"chunk_id"` (one of the available IDs above) and '
+            '`"quote"` (verbatim excerpt from that chunk supporting a finding). '
+            "Only include chunks you actually used."
         )
 
     user_prompt = (
@@ -203,7 +393,7 @@ async def _reviewer_agent(
         f"## Evidence Lines\n{_truncate_at_boundary(evidence_context, 2000)}\n\n"
         f"## Policy Chunks\n{_truncate_at_boundary(policy_context, 3000)}\n\n"
         f"## Historical Answers\n{_truncate_at_boundary(history_context, 2000)}\n\n"
-        "Keep only well-supported findings. Add explicit sources and confidence."
+        "Keep only well-supported findings. Declare which chunks you used in `sources`."
     )
     return await invoke_llm(base_prompt, user_prompt)
 
@@ -225,6 +415,62 @@ def _format_chunks_with_ids(chunks: list, prefix: str) -> str:
             page = metadata.get("page")
             formatted.append(f"[{c_id}] {src} p={page}\n{d.page_content[:600]}")
     return "\n\n".join(formatted)
+
+
+def _build_chunk_lookup(
+    policy_chunks: list,
+    history_chunks: list,
+) -> dict[str, object]:
+    """Build a chunk_id → Document lookup from the chunks passed to the reviewer."""
+    lookup: dict[str, object] = {}
+    for i, d in enumerate(policy_chunks):
+        lookup[f"POL-{i + 1}"] = d
+    for i, d in enumerate(history_chunks):
+        lookup[f"HIS-{i + 1}"] = d
+    return lookup
+
+
+def _resolve_citations_from_llm(
+    llm_sources: list[dict],
+    chunk_lookup: dict[str, object],
+) -> list[SourceCitation]:
+    """Build SourceCitation objects from the reviewer's declared chunk references."""
+    citations: list[SourceCitation] = []
+    seen: set[str] = set()
+
+    for i, src in enumerate(llm_sources):
+        chunk_id = src.get("chunk_id", "")
+        if not chunk_id or chunk_id in seen:
+            continue
+        seen.add(chunk_id)
+
+        doc = chunk_lookup.get(chunk_id)
+        if doc is None:
+            continue
+
+        metadata = doc.metadata or {}
+        file = metadata.get("source", "unknown")
+        page = metadata.get("page")
+        paragraph_id = metadata.get("chunk_id") or metadata.get("document_id")
+        is_history = chunk_id.startswith("HIS-")
+
+        evidence_link = (
+            f"{'history://' if is_history else ''}{file}#chunk={paragraph_id}"
+            if paragraph_id
+            else None
+        )
+        citations.append(
+            SourceCitation(
+                id=f"S{i + 1}",
+                file=file,
+                page=page if isinstance(page, int) else None,
+                paragraph_id=str(paragraph_id) if paragraph_id else None,
+                excerpt=src.get("quote", doc.page_content[:240]),
+                evidence_link=evidence_link,
+                score=float(metadata["score"]) if metadata.get("score") else None,
+            )
+        )
+    return citations
 
 
 def _derive_sources_from_chunks(
@@ -263,6 +509,7 @@ def _parse_llm_output_to_report(
     history_chunks: list,
     scenario_id: str | None = None,
     project_id: str | None = None,
+    chunk_lookup: dict | None = None,
 ) -> AssessmentReport:
     parsed: dict = {}
     try:
@@ -275,7 +522,15 @@ def _parse_llm_output_to_report(
             "confidence": 0.0,
         }
 
-    citations = _derive_sources_from_chunks(policy_chunks, history_chunks)
+    # Prefer citations the reviewer explicitly declared; fall back to all passed chunks.
+    llm_sources = parsed.get("sources", [])
+    if llm_sources and chunk_lookup:
+        citations = _resolve_citations_from_llm(llm_sources, chunk_lookup)
+    else:
+        citations = []
+
+    if not citations:
+        citations = _derive_sources_from_chunks(policy_chunks, history_chunks)
 
     return AssessmentReport(
         task_id=str(task_id),

--- a/app/kb/service.py
+++ b/app/kb/service.py
@@ -285,31 +285,72 @@ class KnowledgeBaseService:
         scenario_id: str | None,
         report_json: dict,
     ) -> str:
-        content = (
-            f"task_id={task_id}\nversion={version}\nscenario_id={scenario_id}\n"
-            f"{json.dumps(report_json, ensure_ascii=False)}"
-        )
-        doc_id = hashlib.sha256(content.encode()).hexdigest()[:16]
-        chunks = self._splitter.split_text(content)
-        docs = [
-            Document(
-                page_content=c,
-                metadata={
-                    "source": f"history/{task_id}/v{version}.json",
-                    "document_id": doc_id,
-                    "type": "history_response",
-                    "task_id": task_id,
-                    "version": version,
-                    "scenario_id": scenario_id,
-                    "chunk_id": f"{doc_id}_{i}",
-                },
+        """Store each finding as a separate searchable document.
+
+        Prior implementation chunked the whole report JSON by character count,
+        which split JSON structure mid-object and made retrieval semantically
+        meaningless.  Storing findings individually means a similarity search
+        for "weak authentication" returns a matching RiskItem, not a JSON
+        fragment that happens to contain the words.
+        """
+        doc_id = hashlib.sha256(
+            f"{task_id}-v{version}".encode()
+        ).hexdigest()[:16]
+        source = f"history/{task_id}/v{version}.json"
+        base_meta: dict = {
+            "source": source,
+            "document_id": doc_id,
+            "task_id": task_id,
+            "version": version,
+            "scenario_id": scenario_id,
+        }
+
+        docs: list[Document] = []
+
+        # Summary
+        summary_text = report_json.get("summary", "")
+        if summary_text:
+            chunk_id = f"{doc_id}_summary"
+            docs.append(
+                Document(
+                    page_content=f"SUMMARY: {summary_text}",
+                    metadata={**base_meta, "type": "history_summary", "chunk_id": chunk_id},
+                )
             )
-            for i, c in enumerate(chunks)
-        ]
+
+        # Individual risk items
+        for i, item in enumerate(report_json.get("risk_items", [])):
+            content = (
+                f"RISK [{item.get('severity', 'unknown').upper()}]: "
+                f"{item.get('title', '')}\n"
+                f"{item.get('description', '')}"
+            )
+            chunk_id = f"{doc_id}_risk_{i}"
+            docs.append(
+                Document(
+                    page_content=content,
+                    metadata={**base_meta, "type": "history_risk_item", "chunk_id": chunk_id},
+                )
+            )
+
+        # Individual compliance gaps
+        for i, gap in enumerate(report_json.get("compliance_gaps", [])):
+            content = (
+                f"GAP [{gap.get('framework', '')}]: "
+                f"{gap.get('control_or_clause', '')}\n"
+                f"{gap.get('gap_description', '')}"
+            )
+            chunk_id = f"{doc_id}_gap_{i}"
+            docs.append(
+                Document(
+                    page_content=content,
+                    metadata={**base_meta, "type": "history_compliance_gap", "chunk_id": chunk_id},
+                )
+            )
+
         if docs:
-            self._history_store.add_documents(
-                docs, ids=[f"{doc_id}_{i}" for i in range(len(docs))]
-            )
+            ids = [d.metadata["chunk_id"] for d in docs]
+            self._history_store.add_documents(docs, ids=ids)
         return doc_id
 
     def query_history_responses(self, query: str, top_k: int = 3) -> list[Document]:

--- a/tests/test_kb_history.py
+++ b/tests/test_kb_history.py
@@ -1,0 +1,140 @@
+"""Tests for KB history storage granularity (P2 fix)."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_kb():
+    """Return a KnowledgeBaseService with an in-memory Chroma stub."""
+    from app.kb.service import KnowledgeBaseService
+
+    kb = object.__new__(KnowledgeBaseService)
+    kb._initialized = False
+
+    # Stub the history store with a real in-memory list so we can inspect docs.
+    stored_docs: list = []
+    stored_ids: list = []
+
+    mock_store = MagicMock()
+
+    def fake_add_documents(docs, ids=None):
+        stored_docs.extend(docs)
+        if ids:
+            stored_ids.extend(ids)
+
+    mock_store.add_documents.side_effect = fake_add_documents
+    kb._history_store = mock_store
+    kb._stored_docs = stored_docs
+    kb._stored_ids = stored_ids
+    return kb
+
+
+def test_history_stores_summary_as_separate_doc():
+    kb = _make_kb()
+    kb.add_history_response(
+        task_id="t1",
+        version=1,
+        scenario_id=None,
+        report_json={"summary": "All controls passed.", "risk_items": [], "compliance_gaps": []},
+    )
+    texts = [d.page_content for d in kb._stored_docs]
+    assert any("All controls passed." in t for t in texts)
+
+
+def test_history_stores_each_risk_item_separately():
+    kb = _make_kb()
+    report = {
+        "summary": "Two risks found.",
+        "risk_items": [
+            {"title": "Weak Auth", "severity": "high", "description": "No MFA."},
+            {"title": "Open Port", "severity": "medium", "description": "Port 22 exposed."},
+        ],
+        "compliance_gaps": [],
+    }
+    kb.add_history_response("t2", 1, None, report)
+    texts = [d.page_content for d in kb._stored_docs]
+
+    assert any("Weak Auth" in t for t in texts)
+    assert any("Open Port" in t for t in texts)
+    # Each risk item is its own document — not merged into one blob.
+    weak_auth_docs = [t for t in texts if "Weak Auth" in t]
+    open_port_docs = [t for t in texts if "Open Port" in t]
+    assert len(weak_auth_docs) == 1
+    assert len(open_port_docs) == 1
+
+
+def test_history_stores_each_compliance_gap_separately():
+    kb = _make_kb()
+    report = {
+        "summary": "Gap found.",
+        "risk_items": [],
+        "compliance_gaps": [
+            {
+                "control_or_clause": "A.9.1",
+                "gap_description": "No access review process.",
+                "framework": "ISO 27001",
+            },
+            {
+                "control_or_clause": "Art. 32",
+                "gap_description": "Encryption not documented.",
+                "framework": "GDPR",
+            },
+        ],
+    }
+    kb.add_history_response("t3", 1, None, report)
+    texts = [d.page_content for d in kb._stored_docs]
+
+    assert any("A.9.1" in t for t in texts)
+    assert any("Art. 32" in t for t in texts)
+
+
+def test_history_doc_count_equals_summary_plus_findings():
+    kb = _make_kb()
+    report = {
+        "summary": "Summary text.",
+        "risk_items": [
+            {"title": "R1", "severity": "low", "description": "d1"},
+            {"title": "R2", "severity": "high", "description": "d2"},
+        ],
+        "compliance_gaps": [
+            {"control_or_clause": "G1", "gap_description": "g1", "framework": "ISO"},
+        ],
+    }
+    kb.add_history_response("t4", 1, "s1", report)
+    # 1 summary + 2 risk_items + 1 compliance_gap = 4 docs
+    assert len(kb._stored_docs) == 4
+
+
+def test_history_each_doc_has_unique_chunk_id():
+    kb = _make_kb()
+    report = {
+        "summary": "s",
+        "risk_items": [{"title": "R", "severity": "low", "description": "d"}],
+        "compliance_gaps": [],
+    }
+    kb.add_history_response("t5", 1, None, report)
+    ids = kb._stored_ids
+    assert len(ids) == len(set(ids)), "Duplicate chunk IDs detected"
+
+
+def test_history_metadata_carries_task_and_version():
+    kb = _make_kb()
+    report = {"summary": "ok", "risk_items": [], "compliance_gaps": []}
+    kb.add_history_response("task-xyz", 3, "scene-1", report)
+    for doc in kb._stored_docs:
+        assert doc.metadata["task_id"] == "task-xyz"
+        assert doc.metadata["version"] == 3
+        assert doc.metadata["scenario_id"] == "scene-1"
+
+
+def test_history_severity_included_in_risk_item_content():
+    kb = _make_kb()
+    report = {
+        "summary": "s",
+        "risk_items": [{"title": "SQL Injection", "severity": "critical", "description": "Unsanitized input."}],
+        "compliance_gaps": [],
+    }
+    kb.add_history_response("t6", 1, None, report)
+    texts = [d.page_content for d in kb._stored_docs]
+    risk_texts = [t for t in texts if "SQL Injection" in t]
+    assert len(risk_texts) == 1
+    assert "CRITICAL" in risk_texts[0]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,64 +4,360 @@ from uuid import uuid4
 
 import pytest
 
-from app.agent.orchestrator import run_assessment
+from app.agent.orchestrator import (
+    _build_chunk_lookup,
+    _evidence_agent_keyword_fallback,
+    _extract_query_seed,
+    _resolve_citations_from_llm,
+    _split_text_with_overlap,
+    run_assessment,
+)
 from app.models.parser import ParsedDocument, ParsedDocumentMetadata
 from app.models.skill import Skill
 
 
-@pytest.mark.asyncio
-async def test_orchestrator_uses_skill_prompt():
-    """Verify that providing a skill_id injects the skill prompt into LLM calls."""
-
-    # Mock dependencies
-    mock_skill = Skill(
+def _make_skill(**kwargs) -> Skill:
+    defaults = dict(
         id="test-skill",
         name="Test Skill",
         description="A test skill",
         system_prompt="YOU ARE A TEST SKILL",
         risk_focus=["Testing"],
-        compliance_frameworks=["TEST-101"]
+        compliance_frameworks=["TEST-101"],
+    )
+    defaults.update(kwargs)
+    return Skill(**defaults)
+
+
+def _make_doc(content: str = "Test document content.", filename: str = "test.md") -> ParsedDocument:
+    return ParsedDocument(
+        content=content,
+        metadata=ParsedDocumentMetadata(filename=filename, type="md"),
     )
 
-    # Mock Skill Service
-    with patch("app.agent.orchestrator.get_skill_service") as mock_get_service:
-        mock_service_instance = MagicMock()
-        mock_service_instance.get_skill.return_value = mock_skill
-        mock_get_service.return_value = mock_service_instance
 
-        # Mock LLM
-        with patch("app.agent.orchestrator.invoke_llm", new_callable=AsyncMock) as mock_invoke:
-            mock_invoke.return_value = '{"summary": "Test", "risk_items": []}'
+def _patch_deps(skill, llm_response='{"summary": "Test", "risk_items": []}'):
+    """Return a context manager that patches skill service, LLM, and KB."""
+    import contextlib
 
-            # Mock KB (to avoid actual DB calls)
-            with patch("app.agent.orchestrator.get_kb_service") as mock_get_kb:
+    @contextlib.contextmanager
+    def _ctx():
+        with patch("app.agent.orchestrator.get_skill_service") as mock_svc:
+            mock_svc_instance = MagicMock()
+            mock_svc_instance.get_skill.return_value = skill
+            mock_svc_instance.list_skills.return_value = [skill]
+            mock_svc.return_value = mock_svc_instance
+
+            with patch("app.agent.orchestrator.invoke_llm", new_callable=AsyncMock) as mock_llm:
+                mock_llm.return_value = llm_response
+
+                with patch("app.agent.orchestrator.get_kb_service") as mock_kb_svc:
+                    mock_kb = MagicMock()
+                    mock_kb.query = AsyncMock(return_value=[])
+                    mock_kb.query_history_responses.return_value = []
+                    mock_kb_svc.return_value = mock_kb
+
+                    yield mock_llm
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# Existing test — skill prompt injection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_orchestrator_uses_skill_prompt():
+    skill = _make_skill()
+    with _patch_deps(skill) as mock_invoke:
+        await run_assessment(uuid4(), [_make_doc()], skill_id="test-skill")
+
+        calls = mock_invoke.call_args_list
+        found = any("YOU ARE A TEST SKILL" in call.args[0] for call in calls)
+        assert found, "Skill system prompt was not injected into LLM calls"
+
+
+# ---------------------------------------------------------------------------
+# P1: semantic query seed
+# ---------------------------------------------------------------------------
+
+def test_extract_query_seed_short_text_returned_unchanged():
+    text = "Short text."
+    assert _extract_query_seed(text, max_chars=2000) == text
+
+
+def test_extract_query_seed_no_focus_returns_head():
+    text = "A" * 3000
+    seed = _extract_query_seed(text, skill_focus=None, max_chars=2000)
+    assert len(seed) <= 2000
+    assert seed == text[:2000]
+
+
+def test_extract_query_seed_prefers_paragraphs_with_focus_terms():
+    irrelevant = "The weather is nice today.\n\n" * 20
+    relevant = "Access control and encryption are critical security controls."
+    text = irrelevant + "\n\n" + relevant
+    seed = _extract_query_seed(
+        text,
+        skill_focus=["Access Control", "Encryption"],
+        max_chars=300,
+    )
+    assert "Access control" in seed or "encryption" in seed.lower()
+
+
+def test_extract_query_seed_respects_max_chars():
+    text = "\n\n".join(["paragraph " + str(i) for i in range(100)])
+    seed = _extract_query_seed(text, skill_focus=["paragraph"], max_chars=500)
+    assert len(seed) <= 500
+
+
+# ---------------------------------------------------------------------------
+# P0: evidence agent
+# ---------------------------------------------------------------------------
+
+def test_evidence_agent_keyword_fallback_finds_matches():
+    doc = _make_doc("The password must be at least 12 characters.\nUnrelated line.")
+    result = _evidence_agent_keyword_fallback([doc], skill_focus=["Authentication"])
+    assert "password" in result.lower()
+    assert "test.md#L" in result
+
+
+def test_evidence_agent_keyword_fallback_empty_doc():
+    doc = _make_doc("No relevant content here.", filename="empty.md")
+    result = _evidence_agent_keyword_fallback([doc], skill_focus=[])
+    # Falls through to the no-match message
+    assert result  # must return something (not crash)
+
+
+def test_evidence_agent_keyword_fallback_skill_focus_expands_keywords():
+    doc = _make_doc("Data residency requirement: EU only.\nOther line.")
+    result = _evidence_agent_keyword_fallback([doc], skill_focus=["data residency"])
+    assert "data residency" in result.lower() or "residency" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_evidence_agent_uses_llm_extraction():
+    skill = _make_skill()
+    with _patch_deps(skill, llm_response="test.md#L1: The password must be rotated") as mock_llm:
+        await run_assessment(uuid4(), [_make_doc()], skill_id="test-skill")
+    # LLM should have been called at least once for evidence extraction
+    assert mock_llm.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_evidence_agent_falls_back_when_llm_raises():
+    """Evidence extraction must not propagate LLM errors — keyword fallback takes over."""
+    skill = _make_skill()
+
+    call_count = 0
+
+    async def selective_llm(system_prompt: str, user_prompt: str) -> str:
+        nonlocal call_count
+        call_count += 1
+        # Fail only the evidence extraction call (identified by its system prompt).
+        if "evidence extractor" in system_prompt:
+            raise RuntimeError("LLM unavailable")
+        return '{"summary": "ok", "risk_items": []}'
+
+    with patch("app.agent.orchestrator.get_skill_service") as mock_svc:
+        inst = MagicMock()
+        inst.get_skill.return_value = skill
+        inst.list_skills.return_value = [skill]
+        mock_svc.return_value = inst
+
+        with patch("app.agent.orchestrator.invoke_llm", side_effect=selective_llm):
+            with patch("app.agent.orchestrator.get_kb_service") as mock_kb_svc:
                 mock_kb = MagicMock()
                 mock_kb.query = AsyncMock(return_value=[])
                 mock_kb.query_history_responses.return_value = []
-                mock_get_kb.return_value = mock_kb
+                mock_kb_svc.return_value = mock_kb
 
-                # Input
-                parsed_docs = [
-                    ParsedDocument(
-                        content="This is a test doc.",
-                        metadata=ParsedDocumentMetadata(filename="test.md", type="md")
-                    )
-                ]
+                # Should complete without raising, using keyword fallback for evidence.
+                report = await run_assessment(
+                    uuid4(),
+                    [_make_doc("The token must be stored securely.")],
+                    skill_id="test-skill",
+                )
+    assert report.summary == "ok"
 
-                # Run
-                await run_assessment(uuid4(), parsed_docs, skill_id="test-skill")
 
-                # Verify
-                # Check that invoke_llm was called with the skill prompt
-                calls = mock_invoke.call_args_list
+# ---------------------------------------------------------------------------
+# P0: citation traceability
+# ---------------------------------------------------------------------------
 
-                # We expect calls for Drafter, Reviewer, (maybe Confidence)
-                # Let's check if "YOU ARE A TEST SKILL" is in any of the system prompts (first arg)
-                found_skill_prompt = False
-                for call in calls:
-                    system_prompt = call.args[0]
-                    if "YOU ARE A TEST SKILL" in system_prompt:
-                        found_skill_prompt = True
-                        break
+def test_build_chunk_lookup_maps_pol_and_his_ids():
+    from langchain_core.documents import Document
 
-                assert found_skill_prompt, "Skill system prompt was not injected into LLM calls"
+    pol = [Document(page_content="policy text", metadata={"source": "pol.pdf"})]
+    his = [Document(page_content="history text", metadata={"source": "his.json"})]
+    lookup = _build_chunk_lookup(pol, his)
+    assert "POL-1" in lookup
+    assert "HIS-1" in lookup
+    assert lookup["POL-1"].page_content == "policy text"
+
+
+def test_resolve_citations_uses_declared_chunk_ids():
+    from langchain_core.documents import Document
+
+    pol = Document(
+        page_content="Encryption must use AES-256.",
+        metadata={"source": "policy.pdf", "document_id": "abc123", "page": 3},
+    )
+    lookup = {"POL-1": pol}
+
+    llm_sources = [
+        {"chunk_id": "POL-1", "quote": "Encryption must use AES-256."},
+    ]
+    citations = _resolve_citations_from_llm(llm_sources, lookup)
+    assert len(citations) == 1
+    assert citations[0].file == "policy.pdf"
+    assert citations[0].excerpt == "Encryption must use AES-256."
+    assert citations[0].page == 3
+
+
+def test_resolve_citations_skips_unknown_chunk_ids():
+    from langchain_core.documents import Document
+
+    pol = Document(page_content="policy text", metadata={"source": "p.pdf"})
+    lookup = {"POL-1": pol}
+    llm_sources = [{"chunk_id": "POL-99", "quote": "nonexistent"}]
+    citations = _resolve_citations_from_llm(llm_sources, lookup)
+    assert citations == []
+
+
+def test_resolve_citations_deduplicates_chunk_ids():
+    from langchain_core.documents import Document
+
+    pol = Document(page_content="policy text", metadata={"source": "p.pdf"})
+    lookup = {"POL-1": pol}
+    llm_sources = [
+        {"chunk_id": "POL-1", "quote": "first"},
+        {"chunk_id": "POL-1", "quote": "duplicate"},
+    ]
+    citations = _resolve_citations_from_llm(llm_sources, lookup)
+    assert len(citations) == 1
+
+
+def test_resolve_citations_history_prefix_in_evidence_link():
+    from langchain_core.documents import Document
+
+    his = Document(
+        page_content="old finding",
+        metadata={"source": "history/t1/v1.json", "document_id": "d1"},
+    )
+    lookup = {"HIS-1": his}
+    llm_sources = [{"chunk_id": "HIS-1", "quote": "old finding"}]
+    citations = _resolve_citations_from_llm(llm_sources, lookup)
+    assert citations[0].evidence_link.startswith("history://")
+
+
+@pytest.mark.asyncio
+async def test_citations_from_reviewer_output_used_over_fallback():
+    """When the reviewer returns valid chunk_id sources, those become the report citations."""
+    from langchain_core.documents import Document
+
+    skill = _make_skill()
+    pol_doc = Document(
+        page_content="Access tokens must expire within 1 hour.",
+        metadata={"source": "policy.pdf", "document_id": "pol001", "page": 5},
+    )
+
+    reviewer_response = (
+        '{"summary":"ok","confidence":0.9,"risk_items":[],'
+        '"compliance_gaps":[],"remediations":[],'
+        '"sources":[{"chunk_id":"POL-1","quote":"Access tokens must expire within 1 hour."}]}'
+    )
+
+    call_num = 0
+
+    async def mock_llm(system_prompt, user_prompt):
+        nonlocal call_num
+        call_num += 1
+        # Drafter and evidence calls get a generic response; reviewer gets the citation-rich one.
+        if "Reviewer" in system_prompt or "Validate" in system_prompt:
+            return reviewer_response
+        return '{"summary":"draft","risk_items":[]}'
+
+    with patch("app.agent.orchestrator.get_skill_service") as mock_svc:
+        inst = MagicMock()
+        inst.get_skill.return_value = skill
+        inst.list_skills.return_value = [skill]
+        mock_svc.return_value = inst
+
+        with patch("app.agent.orchestrator.invoke_llm", side_effect=mock_llm):
+            with patch("app.agent.orchestrator.get_kb_service") as mock_kb_svc:
+                mock_kb = MagicMock()
+                mock_kb.query = AsyncMock(return_value=[pol_doc])
+                mock_kb.query_history_responses.return_value = []
+                mock_kb_svc.return_value = mock_kb
+
+                report = await run_assessment(
+                    uuid4(), [_make_doc()], skill_id="test-skill"
+                )
+
+    assert len(report.sources) == 1
+    assert report.sources[0].file == "policy.pdf"
+    assert report.sources[0].excerpt == "Access tokens must expire within 1 hour."
+
+
+# ---------------------------------------------------------------------------
+# P1: large-document map-reduce
+# ---------------------------------------------------------------------------
+
+def test_split_text_with_overlap_small_text_unchanged():
+    text = "short text"
+    chunks = _split_text_with_overlap(text, chunk_size=100, overlap=10)
+    assert chunks == [text]
+
+
+def test_split_text_with_overlap_produces_multiple_chunks():
+    text = ("word " * 500).strip()  # ~2500 chars
+    chunks = _split_text_with_overlap(text, chunk_size=1000, overlap=100)
+    assert len(chunks) >= 2
+
+
+def test_split_text_with_overlap_chunks_cover_full_document():
+    text = ("abc " * 1000).strip()
+    chunks = _split_text_with_overlap(text, chunk_size=500, overlap=50)
+    # Every character in the original should appear in at least one chunk.
+    combined = "".join(chunks)
+    # The combined length >= original (overlap means repetition)
+    assert len(combined) >= len(text)
+
+
+@pytest.mark.asyncio
+async def test_large_document_triggers_map_reduce():
+    """Documents exceeding _LARGE_DOC_THRESHOLD must invoke MergeAgent."""
+    from app.agent.orchestrator import _LARGE_DOC_THRESHOLD
+
+    skill = _make_skill()
+    large_content = "Security controls are critical. " * ((_LARGE_DOC_THRESHOLD // 30) + 10)
+
+    merge_called = False
+
+    async def mock_llm(system_prompt, user_prompt):
+        nonlocal merge_called
+        if "MergeAgent" in system_prompt:
+            merge_called = True
+        return '{"summary":"merged","risk_items":[]}'
+
+    with patch("app.agent.orchestrator.get_skill_service") as mock_svc:
+        inst = MagicMock()
+        inst.get_skill.return_value = skill
+        inst.list_skills.return_value = [skill]
+        mock_svc.return_value = inst
+
+        with patch("app.agent.orchestrator.invoke_llm", side_effect=mock_llm):
+            with patch("app.agent.orchestrator.get_kb_service") as mock_kb_svc:
+                mock_kb = MagicMock()
+                mock_kb.query = AsyncMock(return_value=[])
+                mock_kb.query_history_responses.return_value = []
+                mock_kb_svc.return_value = mock_kb
+
+                await run_assessment(
+                    uuid4(),
+                    [_make_doc(content=large_content)],
+                    skill_id="test-skill",
+                )
+
+    assert merge_called, "MergeAgent was not invoked for a large document"


### PR DESCRIPTION
## Summary

Four targeted fixes to the assessment pipeline, identified via first-principles review.

### P0 — Citation traceability (`orchestrator.py`)
- `_reviewer_agent` prompt now instructs the LLM to declare exactly which `chunk_id`s it used (`POL-N` / `HIS-N`) and provide verbatim quotes.
- New `_build_chunk_lookup` + `_resolve_citations_from_llm` build `SourceCitation` objects from those declarations, replacing the prior behaviour that silently attached all passed-in KB chunks as citations regardless of whether the LLM actually consulted them.
- Falls back to the legacy all-chunks path only when the reviewer returns an empty `sources` array.

### P0 — Semantic evidence extraction (`orchestrator.py`)
- `_evidence_agent` is now `async` and issues an LLM call to extract verbatim evidence lines scoped to `skill.risk_focus`, replacing a hardcoded keyword list that missed domain-specific terms ("data residency", "non-repudiation", "privacy by design", etc.).
- Old keyword scan extracted to `_evidence_agent_keyword_fallback` and retained as a fallback when the LLM call fails.

### P1 — Semantic KB query seed (`orchestrator.py`)
- New `_extract_query_seed` scores document paragraphs by `skill.risk_focus` term frequency and greedily packs the highest-scoring ones into the KB query, replacing `combined_input[:2000]` which returned context from the document header regardless of relevance.

### P1 — Large-document map-reduce (`orchestrator.py`)
- Documents longer than 12 000 chars are split into overlapping 10 000-char sections via `_split_text_with_overlap`.
- `_draft_large_document` runs `_drafter_agent` in parallel across sections and consolidates with a new `_merge_drafts` (MergeAgent) call, preventing silent truncation of appendices, exception clauses, and definitions that often appear at the end of security documents.

### P2 — History storage granularity (`kb/service.py`)
- `add_history_response` now stores each `RiskItem` and `ComplianceGap` as a separate `Document` in the history vector store, replacing character-chunked JSON blobs that split objects mid-structure and made similarity retrieval semantically meaningless.

## Test plan

- [ ] `pytest tests/test_orchestrator.py tests/test_kb_history.py` — 27 new/updated unit tests, all green locally (Python 3.11)
- [ ] Existing test `test_orchestrator_uses_skill_prompt` still passes (no breaking changes to public API)
- [ ] Manual: run a STRIDE assessment on a multi-page PDF and verify citations map to real KB chunks
- [ ] Manual: run on a document > 12 000 chars and confirm MergeAgent fires in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)