### PR TITLE
fix: guard docs static mount and improve build correctness

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -70,7 +70,8 @@ app.include_router(
 )
 
 # Mount docs directory for demo purposes
-app.mount("/docs", StaticFiles(directory="docs", html=True), name="docs")
+if Path("docs").exists():
+    app.mount("/docs", StaticFiles(directory="docs", html=True), name="docs")
 
 console_dist = Path("frontend/dist")
 if console_dist.exists():


### PR DESCRIPTION
## Summary

- Fixed a `RuntimeError` at app startup/import when the `docs/` directory does not exist relative to the working directory (e.g. during tests or CI runs from a non-root CWD)
- Wrapped `app.mount(\"/docs\", StaticFiles(...))` in a `Path(\"docs\").exists()` guard — consistent with the existing `frontend/dist` conditional mount immediately below it
- Merged upstream fixes from `main`: Python 3.10 `datetime.UTC` compatibility (`timezone.utc` replacement across `orchestrator.py`, `security.py`, `parser.py`), React console frontend, and LLM config API

## What changed and why

`app/main.py:73` previously called `StaticFiles(directory="docs")` unconditionally at module import time. FastAPI/Starlette raises `RuntimeError: Directory 'docs' does not exist` if the directory is missing, which breaks all 63 tests (and any environment where the process isn't launched from the project root). The fix adds a simple existence check before mounting.

## Test plan

- [x] All 63 existing tests pass with the fix (`pytest tests/`)
- [x] Branch is up to date with `main` (fast-forward merge applied)
- [ ] Frontend build (`npm run build --prefix frontend`) — requires Node.js, not available in this environment; no frontend logic was changed

## Reviewer notes

The only source change in this PR is the two-line guard in `app/main.py`. Everything else is the upstream merge from `main` (commits already reviewed via PRs #8–#10).