### PR TITLE
Add evaluation harness M0 and M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,33 @@ REST API, or expose the same assessment capabilities to AI agents (Claude Deskto
 Cursor, OpenClaw) through MCP. A2A-compatible platforms can delegate assessment
 tasks to DocSentinel as a specialist security agent.
 
+### Reproducible Evaluation Harness
+DocSentinel includes an `evals/` harness for measuring assessment quality against
+public and future golden datasets without going through HTTP or the UI. The first
+implemented path covers OWASP Benchmark v1.2 SAST triage:
+
+- **Dataset hygiene**: raw benchmark data is fetched locally into ignored paths;
+  only the fetch script, checksum, manifest, and tiny test fixture are committed.
+- **Direct pipeline execution**: the runner calls `AssessmentService.submit()`
+  with `phase="testing"` and `skill_id="ssdlc-testing"`, matching production task
+  semantics while staying self-contained.
+- **Hard-key scoring**: M1 scores CWE-based binary triage with accuracy,
+  precision, recall, F1, and false-positive rate, with no LLM judge.
+- **Scorecards**: every run writes machine-readable `scorecard.json` and a
+  human-readable `scorecard.md` under `evals/reports/<run_id>/`.
+
+```bash
+python evals/datasets/owasp_benchmark/fetch.py
+python -m evals.runner.run_eval \
+  --dataset-id owasp_benchmark \
+  --raw-dir evals/datasets/owasp_benchmark/raw/BenchmarkJava-master \
+  --run-id local-owasp \
+  --repeats 1
+```
+
+See [docs/07-evaluation-plan.md](./docs/07-evaluation-plan.md) for the full
+methodology and milestone roadmap.
+
 ---
 
 ## Agent Integration (MCP + A2A)
@@ -495,6 +522,7 @@ DocSentinel/
 │   ├── main.py           # FastAPI app entry point
 │   └── mcp_server.py     # MCP stdio + Streamable HTTP tools
 ├── tests/                # Automated tests (pytest)
+├── evals/                # Reproducible quality eval harness and scorecards
 ├── examples/             # Sample files (questionnaires, policies, reports)
 ├── docs/                 # Design & Spec documentation
 │   ├── 01-architecture-and-tech-stack.md
@@ -503,6 +531,7 @@ DocSentinel/
 │   ├── 04-integration-guide.md
 │   ├── 05-deployment-runbook.md
 │   ├── 06-agent-integration.md
+│   ├── 07-evaluation-plan.md
 │   └── schemas/
 ├── .github/              # Issue/PR templates, CI (Actions)
 ├── Dockerfile
@@ -574,6 +603,7 @@ DocSentinel/
 -   **[SPEC.md](./SPEC.md)** — Product requirements: SSDLC phases, features, security controls.
 -   **[CHANGELOG.md](./CHANGELOG.md)** — Version history; [Releases](https://github.com/arthurpanhku/DocSentinel/releases).
 -   **Design docs** [docs/](./docs/): Architecture, API spec (OpenAPI), contracts, integration guides, deployment runbook.
+-   **[docs/07-evaluation-plan.md](./docs/07-evaluation-plan.md)** — Evaluation methodology and milestone plan for `evals/`.
 
 ---
 
@@ -590,6 +620,7 @@ chmod +x test_integration.sh
 pip install -r requirements-dev.txt
 pytest
 pytest tests/test_skills_api.py   # Run specific test
+pytest evals/tests                # Run evaluation harness tests
 ```
 
 ## Contributing

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,30 @@
+# DocSentinel Evaluations
+
+This directory contains the reproducible evaluation harness described in
+`docs/07-evaluation-plan.md`.
+
+Current scope:
+
+- **M0**: evaluation layout, `EvalCase`, `RunConfig`, and dataset registry.
+- **M1**: OWASP Benchmark SAST triage adapter, direct `AssessmentService` runner,
+  hard-key CWE triage scoring, and scorecard outputs.
+
+Raw datasets are not committed. Use the dataset-specific fetch script to download
+public data into ignored local paths.
+
+```bash
+python evals/datasets/owasp_benchmark/fetch.py
+python -m evals.runner.run_eval \
+  --dataset-id owasp_benchmark \
+  --raw-dir evals/datasets/owasp_benchmark/raw/BenchmarkJava-master \
+  --run-id local-owasp \
+  --repeats 1
+```
+
+The runner writes:
+
+- `evals/reports/<run_id>/scorecard.json`
+- `evals/reports/<run_id>/scorecard.md`
+
+M1 uses deterministic hard-key CWE triage scoring and does not use an LLM judge.
+

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,2 @@
+"""DocSentinel evaluation harness."""
+

--- a/evals/adapters/__init__.py
+++ b/evals/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""Dataset adapters that normalize raw data into EvalCase objects."""
+

--- a/evals/adapters/owasp_benchmark.py
+++ b/evals/adapters/owasp_benchmark.py
@@ -1,0 +1,116 @@
+"""OWASP Benchmark v1.2 adapter.
+
+The adapter reads `expectedresults-1.2.csv` from a locally fetched Benchmark
+checkout and yields one EvalCase per test servlet. It does not vendor or fetch
+raw data by itself; use `evals/datasets/owasp_benchmark/fetch.py`.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Iterable
+from pathlib import Path
+
+from evals.models import EvalCase, EvalGroundTruth, EvalInput, VulnerabilityTruth
+
+DATASET_ID = "owasp_benchmark"
+DEFAULT_PHASE = "testing"
+DEFAULT_SKILL_ID = "ssdlc-testing"
+EXPECTED_RESULTS = "expectedresults-1.2.csv"
+
+
+def to_cases(raw_dir: Path) -> Iterable[EvalCase]:
+    """Convert a local OWASP Benchmark checkout into normalized EvalCase objects."""
+    raw_dir = Path(raw_dir)
+    expected_results = _find_expected_results(raw_dir)
+    for row in _read_expected_results(expected_results):
+        test_name = row["test_name"]
+        source_path = _source_path(raw_dir, test_name)
+        yield EvalCase(
+            case_id=test_name,
+            dataset_id=DATASET_ID,
+            phase=DEFAULT_PHASE,
+            skill_id=DEFAULT_SKILL_ID,
+            inputs=[
+                EvalInput(
+                    path=str(source_path.relative_to(raw_dir)),
+                    type="java",
+                )
+            ],
+            ground_truth=EvalGroundTruth(
+                vulnerabilities=[
+                    VulnerabilityTruth(
+                        cwe=_normalize_cwe(row["cwe"]),
+                        label=(
+                            "true_positive"
+                            if row["real_vulnerability"]
+                            else "false_positive"
+                        ),
+                        category=row["category"],
+                        test_name=test_name,
+                    )
+                ]
+            ),
+            meta={
+                "license": "Apache-2.0-ish; verify upstream project terms",
+                "contamination_risk": "high",
+                "source": "OWASP Benchmark v1.2",
+                "expected_results": str(expected_results.relative_to(raw_dir)),
+            },
+        )
+
+
+def _find_expected_results(raw_dir: Path) -> Path:
+    direct = raw_dir / EXPECTED_RESULTS
+    if direct.exists():
+        return direct
+    matches = sorted(raw_dir.glob(f"**/{EXPECTED_RESULTS}"))
+    if matches:
+        return matches[0]
+    raise FileNotFoundError(f"{EXPECTED_RESULTS} not found under {raw_dir}")
+
+
+def _read_expected_results(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for raw in reader:
+            normalized = {
+                _clean_header(key): (value or "").strip()
+                for key, value in raw.items()
+                if key is not None
+            }
+            test_name = normalized.get("test_name", "")
+            cwe = normalized.get("cwe", "")
+            category = normalized.get("category", "")
+            real = normalized.get("real_vulnerability", "").lower()
+            if not test_name or not cwe:
+                continue
+            rows.append(
+                {
+                    "test_name": test_name,
+                    "category": category,
+                    "real_vulnerability": real == "true",
+                    "cwe": cwe,
+                }
+            )
+    return rows
+
+
+def _source_path(raw_dir: Path, test_name: str) -> Path:
+    matches = sorted(raw_dir.glob(f"**/{test_name}.java"))
+    if matches:
+        return matches[0]
+    return raw_dir / "src/main/java/org/owasp/benchmark/testcode" / f"{test_name}.java"
+
+
+def _clean_header(value: str) -> str:
+    return value.strip().lower().lstrip("#").strip().replace(" ", "_")
+
+
+def _normalize_cwe(value: object) -> str:
+    text = str(value).strip().upper()
+    if not text:
+        return ""
+    return text if text.startswith("CWE-") else f"CWE-{text}"
+

--- a/evals/configs/matrix.yaml
+++ b/evals/configs/matrix.yaml
@@ -1,0 +1,17 @@
+defaults:
+  repeats: 3
+  temperature: 0.0
+  timeout_seconds: 300
+
+datasets:
+  owasp_benchmark:
+    repeats: 1
+    phase: testing
+    skill_id: ssdlc-testing
+
+models:
+  - id: ollama-local
+    provider: ollama
+    model_id: llama2
+    temperature: 0.0
+

--- a/evals/datasets/owasp_benchmark/.gitignore
+++ b/evals/datasets/owasp_benchmark/.gitignore
@@ -1,0 +1,6 @@
+raw/
+downloads/
+*.zip
+*.tar.gz
+BenchmarkJava*/
+

--- a/evals/datasets/owasp_benchmark/fetch.py
+++ b/evals/datasets/owasp_benchmark/fetch.py
@@ -1,0 +1,102 @@
+"""Fetch OWASP Benchmark data into ignored local directories.
+
+This script intentionally keeps raw data out of git. It downloads the upstream
+archive, records its SHA-256 in `evals/registry.yaml`, extracts it under
+`evals/datasets/owasp_benchmark/raw/`, and records the number of rows in
+`expectedresults-1.2.csv`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import shutil
+import zipfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+import yaml
+
+ARCHIVE_URL = (
+    "https://github.com/OWASP-Benchmark/BenchmarkJava/archive/refs/heads/master.zip"
+)
+DATASET_ID = "owasp_benchmark"
+EXPECTED_RESULTS = "expectedresults-1.2.csv"
+SCRIPT_DIR = Path(__file__).resolve().parent
+EVALS_DIR = SCRIPT_DIR.parents[1]
+REGISTRY_PATH = EVALS_DIR / "registry.yaml"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default=ARCHIVE_URL)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    downloads_dir = SCRIPT_DIR / "downloads"
+    raw_dir = SCRIPT_DIR / "raw"
+    downloads_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = downloads_dir / "BenchmarkJava-master.zip"
+
+    if archive_path.exists() and not args.force:
+        print(f"Using existing archive: {archive_path}")
+    else:
+        print(f"Downloading {args.url}")
+        urlretrieve(args.url, archive_path)
+
+    checksum = _sha256(archive_path)
+    extract_dir = raw_dir / "BenchmarkJava-master"
+    if extract_dir.exists() and args.force:
+        shutil.rmtree(extract_dir)
+    if not extract_dir.exists():
+        with zipfile.ZipFile(archive_path) as zf:
+            zf.extractall(raw_dir)
+
+    expected_results = _find_expected_results(extract_dir)
+    n_cases = _count_cases(expected_results)
+    _update_registry(checksum=checksum, n_cases=n_cases)
+    print(f"sha256={checksum}")
+    print(f"n_cases={n_cases}")
+    print(f"raw_dir={extract_dir}")
+    return 0
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_expected_results(raw_dir: Path) -> Path:
+    matches = sorted(raw_dir.glob(f"**/{EXPECTED_RESULTS}"))
+    if not matches:
+        raise FileNotFoundError(f"{EXPECTED_RESULTS} not found under {raw_dir}")
+    return matches[0]
+
+
+def _count_cases(path: Path) -> int:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return sum(1 for _ in csv.DictReader(handle))
+
+
+def _update_registry(*, checksum: str, n_cases: int) -> None:
+    registry = yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8")) or {}
+    datasets = registry.setdefault("datasets", {})
+    dataset = datasets.setdefault(DATASET_ID, {})
+    dataset["checksum_algorithm"] = "sha256"
+    dataset["checksum"] = checksum
+    dataset["checksum_target"] = "source_archive"
+    dataset["n_cases"] = n_cases
+    REGISTRY_PATH.write_text(
+        yaml.safe_dump(registry, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/evals/models.py
+++ b/evals/models.py
@@ -1,0 +1,78 @@
+"""Shared models for the DocSentinel evaluation harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+Phase = Literal[
+    "auto",
+    "requirements",
+    "design",
+    "development",
+    "testing",
+    "deployment",
+    "operations",
+    "full_ssdlc",
+]
+TruthLabel = Literal["true_positive", "false_positive"]
+
+
+class EvalInput(BaseModel):
+    """One input artifact referenced by an evaluation case."""
+
+    path: str
+    type: str
+
+
+class VulnerabilityTruth(BaseModel):
+    """Ground truth for one SAST/DAST triage item."""
+
+    cwe: str
+    label: TruthLabel
+    category: str | None = None
+    test_name: str | None = None
+
+
+class EvalGroundTruth(BaseModel):
+    """Ground-truth item sets, aligned to the assessment report schema."""
+
+    threats: list[dict[str, Any]] = Field(default_factory=list)
+    risk_items: list[dict[str, Any]] = Field(default_factory=list)
+    compliance_gaps: list[dict[str, Any]] = Field(default_factory=list)
+    vulnerabilities: list[VulnerabilityTruth] = Field(default_factory=list)
+
+
+class EvalCase(BaseModel):
+    """Normalized dataset case consumed by runners and scorers."""
+
+    case_id: str
+    dataset_id: str
+    phase: Phase
+    skill_id: str
+    inputs: list[EvalInput]
+    ground_truth: EvalGroundTruth
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+    def write_json(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+
+
+class RunConfig(BaseModel):
+    """Execution settings for one evaluation run."""
+
+    run_id: str = "local"
+    dataset_id: str = "owasp_benchmark"
+    provider: str = "ollama-local"
+    model_id: str = "llama2"
+    temperature: float = 0.0
+    repeats: int = Field(default=3, ge=1)
+    timeout_seconds: int = Field(default=300, ge=1)
+    collaborative: bool = True
+    phase: Phase = "testing"
+    skill_id: str = "ssdlc-testing"
+    limit: int | None = Field(default=None, ge=1)
+

--- a/evals/registry.yaml
+++ b/evals/registry.yaml
@@ -1,0 +1,16 @@
+datasets:
+  owasp_benchmark:
+    id: owasp_benchmark
+    name: OWASP Benchmark v1.2
+    source_url: https://github.com/OWASP-Benchmark/BenchmarkJava
+    source_archive_url: https://github.com/OWASP-Benchmark/BenchmarkJava/archive/refs/heads/master.zip
+    license: Apache-2.0-ish; verify upstream project terms before redistribution
+    phase: testing
+    skill_id: ssdlc-testing
+    adapter: evals.adapters.owasp_benchmark:to_cases
+    checksum_algorithm: sha256
+    checksum: 6331494d8ebf90654a4fd7ad292ff8621ee06cefdd2776214475c76fbaf0dce7
+    checksum_target: source_archive
+    contamination_risk: high
+    n_cases: 2740
+    raw_data_policy: fetch_only_do_not_commit

--- a/evals/reports/.gitignore
+++ b/evals/reports/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!baselines/
+

--- a/evals/runner/__init__.py
+++ b/evals/runner/__init__.py
@@ -1,0 +1,2 @@
+"""Evaluation runners."""
+

--- a/evals/runner/parse.py
+++ b/evals/runner/parse.py
@@ -1,0 +1,43 @@
+"""Input parsing helpers for evaluation cases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.models.parser import ParsedDocument, ParsedDocumentMetadata
+from app.parser import parse_file
+from app.parser.service import ALLOWED_EXTENSIONS
+from evals.models import EvalCase, EvalInput
+
+TEXT_EXTENSIONS = {".java", ".json", ".xml", ".csv", ".yaml", ".yml", ".sarif"}
+
+
+def parse_inputs(case: EvalCase, input_root: Path) -> list[ParsedDocument]:
+    """Parse all inputs for a case into DocSentinel ParsedDocument objects."""
+    return [_parse_input(item, input_root) for item in case.inputs]
+
+
+def _parse_input(item: EvalInput, input_root: Path) -> ParsedDocument:
+    path = (input_root / item.path).resolve()
+    root = input_root.resolve()
+    if not str(path).startswith(str(root)):
+        raise ValueError(f"Input path escapes input root: {item.path}")
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    suffix = path.suffix.lower()
+    content = path.read_bytes()
+    if suffix in ALLOWED_EXTENSIONS:
+        return parse_file(content, path.name)
+    if suffix in TEXT_EXTENSIONS or item.type in {"java", "text", "source"}:
+        text = content.decode("utf-8", errors="replace")
+        return ParsedDocument(
+            content=text,
+            metadata=ParsedDocumentMetadata(
+                filename=path.name,
+                type="txt",
+                parser_engine="legacy",
+            ),
+        )
+    raise ValueError(f"Unsupported eval input type: {item.type} ({path.name})")
+

--- a/evals/runner/run_eval.py
+++ b/evals/runner/run_eval.py
@@ -1,0 +1,317 @@
+"""M1 evaluation runner.
+
+Runs normalized cases through DocSentinel's AssessmentService directly and
+produces machine-readable and human-readable scorecards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.models.assessment import AssessmentReport
+from app.services.assessment_service import AssessmentRunner, AssessmentService
+from evals.models import EvalCase, RunConfig
+from evals.runner.parse import parse_inputs
+from evals.scoring.scorers.triage import (
+    TriageRecord,
+    record_from_report,
+    score_records,
+)
+
+EVALS_DIR = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = EVALS_DIR / "registry.yaml"
+MATRIX_PATH = EVALS_DIR / "configs" / "matrix.yaml"
+
+
+async def run_case(
+    case: EvalCase,
+    cfg: RunConfig,
+    *,
+    input_root: Path,
+    assessment_runner: AssessmentRunner | None = None,
+) -> AssessmentReport:
+    """Run one case through AssessmentService and return its report."""
+    docs = parse_inputs(case, input_root)
+    svc = AssessmentService()
+    if assessment_runner is None:
+        created = await svc.submit(
+            docs,
+            phase=case.phase,
+            skill_id=case.skill_id,
+            collaborative_mode=cfg.collaborative,
+            source="eval",
+        )
+    else:
+        created = await svc.submit(
+            docs,
+            phase=case.phase,
+            skill_id=case.skill_id,
+            collaborative_mode=cfg.collaborative,
+            source="eval",
+            runner=assessment_runner,
+        )
+    result = await svc.wait_for_terminal(
+        str(created.task_id),
+        timeout_seconds=cfg.timeout_seconds,
+    )
+    if result.report is None:
+        raise RuntimeError(
+            f"Assessment for {case.case_id} produced no report: {result.error_message}"
+        )
+    return result.report
+
+
+async def run_cases(
+    cases: Iterable[EvalCase],
+    cfg: RunConfig,
+    *,
+    input_root: Path,
+    report_root: Path | None = None,
+    assessment_runner: AssessmentRunner | None = None,
+) -> dict[str, Any]:
+    """Run cases, score SAST triage, and write scorecard files."""
+    selected = list(cases)
+    if cfg.limit is not None:
+        selected = selected[: cfg.limit]
+
+    records: list[TriageRecord] = []
+    for case in selected:
+        for repeat in range(cfg.repeats):
+            report = await run_case(
+                case,
+                cfg,
+                input_root=input_root,
+                assessment_runner=assessment_runner,
+            )
+            records.append(record_from_report(case, report, repeat))
+
+    scorecard = build_scorecard(
+        records,
+        cfg,
+        n_cases=len(selected),
+        dataset_meta=_dataset_meta(cfg.dataset_id),
+    )
+    write_scorecard(
+        scorecard,
+        (report_root or EVALS_DIR / "reports") / cfg.run_id,
+    )
+    return scorecard
+
+
+def build_scorecard(
+    records: list[TriageRecord],
+    cfg: RunConfig,
+    *,
+    n_cases: int,
+    dataset_meta: dict[str, Any],
+) -> dict[str, Any]:
+    metrics = score_records(records)
+    phase_skill: dict[tuple[str, str], list[TriageRecord]] = {}
+    for record in records:
+        phase_skill.setdefault((record.phase, record.skill_id), []).append(record)
+
+    return {
+        "schema_version": "eval-scorecard-v1",
+        "run_id": cfg.run_id,
+        "created_at": datetime.now(UTC).isoformat(),
+        "dataset": {
+            "id": cfg.dataset_id,
+            "source_url": dataset_meta.get("source_url"),
+            "license": dataset_meta.get("license"),
+            "checksum_algorithm": dataset_meta.get("checksum_algorithm"),
+            "checksum": dataset_meta.get("checksum"),
+            "contamination_risk": dataset_meta.get("contamination_risk"),
+        },
+        "model": {
+            "provider": cfg.provider,
+            "model_id": cfg.model_id,
+            "temperature": cfg.temperature,
+        },
+        "run_config": {
+            "repeats": cfg.repeats,
+            "timeout_seconds": cfg.timeout_seconds,
+            "collaborative": cfg.collaborative,
+            "phase": cfg.phase,
+            "skill_id": cfg.skill_id,
+            "limit": cfg.limit,
+        },
+        "n_cases": n_cases,
+        "n_records": len(records),
+        "metrics": metrics,
+        "by_phase_skill": [
+            {
+                "phase": phase,
+                "skill_id": skill_id,
+                "metrics": score_records(group),
+            }
+            for (phase, skill_id), group in sorted(phase_skill.items())
+        ],
+        "cases": [
+            {
+                "case_id": record.case_id,
+                "repeat": record.repeat,
+                "cwe": record.cwe,
+                "truth_label": record.truth_label,
+                "predicted_positive": record.predicted_positive,
+                "outcome": record.outcome,
+            }
+            for record in records
+        ],
+    }
+
+
+def write_scorecard(scorecard: dict[str, Any], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "scorecard.json").write_text(
+        json.dumps(scorecard, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    (output_dir / "scorecard.md").write_text(
+        render_scorecard_markdown(scorecard),
+        encoding="utf-8",
+    )
+
+
+def render_scorecard_markdown(scorecard: dict[str, Any]) -> str:
+    metrics = scorecard["metrics"]
+    lines = [
+        f"# Eval Scorecard: {scorecard['run_id']}",
+        "",
+        f"- Dataset: `{scorecard['dataset']['id']}`",
+        f"- Model: `{scorecard['model']['provider']}:{scorecard['model']['model_id']}`",
+        f"- Temperature: `{scorecard['model']['temperature']}`",
+        f"- Repeats: `{scorecard['run_config']['repeats']}`",
+        f"- Contamination risk: `{scorecard['dataset']['contamination_risk']}`",
+        "",
+        "## Overall Triage Metrics",
+        "",
+        "| Metric | Value |",
+        "| :--- | ---: |",
+    ]
+    for key in ("accuracy", "precision", "recall", "f1", "false_positive_rate"):
+        lines.append(f"| {key} | {metrics[key]:.4f} |")
+    lines.extend(
+        [
+            f"| TP | {metrics['tp']} |",
+            f"| FP | {metrics['fp']} |",
+            f"| TN | {metrics['tn']} |",
+            f"| FN | {metrics['fn']} |",
+            "",
+            "## By Skill / Phase",
+            "",
+            "| Phase | Skill | Accuracy | Precision | Recall | F1 | FP Rate |",
+            "| :--- | :--- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for item in scorecard["by_phase_skill"]:
+        group = item["metrics"]
+        lines.append(
+            "| {phase} | {skill} | {accuracy:.4f} | {precision:.4f} | "
+            "{recall:.4f} | {f1:.4f} | {fp_rate:.4f} |".format(
+                phase=item["phase"],
+                skill=item["skill_id"],
+                accuracy=group["accuracy"],
+                precision=group["precision"],
+                recall=group["recall"],
+                f1=group["f1"],
+                fp_rate=group["false_positive_rate"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "M1 uses hard-key CWE matching for OWASP Benchmark and no LLM judge.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def load_adapter(dataset_id: str):
+    dataset = _dataset_meta(dataset_id)
+    adapter_path = dataset.get("adapter")
+    if not adapter_path:
+        raise ValueError(f"Dataset has no adapter configured: {dataset_id}")
+    module_name, _, func_name = str(adapter_path).partition(":")
+    if not module_name or not func_name:
+        raise ValueError(f"Invalid adapter path for {dataset_id}: {adapter_path}")
+    module = importlib.import_module(module_name)
+    return getattr(module, func_name)
+
+
+def load_matrix_config(dataset_id: str) -> RunConfig:
+    matrix = _load_yaml(MATRIX_PATH)
+    defaults = dict(matrix.get("defaults") or {})
+    dataset_cfg = dict((matrix.get("datasets") or {}).get(dataset_id) or {})
+    model = (matrix.get("models") or [{}])[0]
+    return RunConfig(
+        dataset_id=dataset_id,
+        provider=str(model.get("provider") or "unknown"),
+        model_id=str(model.get("model_id") or "unknown"),
+        temperature=float(
+            dataset_cfg.get("temperature", defaults.get("temperature", 0.0))
+        ),
+        repeats=int(dataset_cfg.get("repeats", defaults.get("repeats", 3))),
+        timeout_seconds=int(
+            dataset_cfg.get("timeout_seconds", defaults.get("timeout_seconds", 300))
+        ),
+        phase=dataset_cfg.get("phase", "testing"),
+        skill_id=dataset_cfg.get("skill_id", "ssdlc-testing"),
+    )
+
+
+def _dataset_meta(dataset_id: str) -> dict[str, Any]:
+    registry = _load_yaml(REGISTRY_PATH)
+    datasets = registry.get("datasets") or {}
+    if dataset_id not in datasets:
+        raise ValueError(f"Unknown dataset: {dataset_id}")
+    return dict(datasets[dataset_id])
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+async def _main_async(args: argparse.Namespace) -> None:
+    cfg = load_matrix_config(args.dataset_id)
+    cfg = cfg.model_copy(
+        update={
+            "run_id": args.run_id,
+            "repeats": args.repeats or cfg.repeats,
+            "limit": args.limit,
+        }
+    )
+    adapter = load_adapter(args.dataset_id)
+    cases = list(adapter(Path(args.raw_dir)))
+    await run_cases(
+        cases,
+        cfg,
+        input_root=Path(args.raw_dir),
+        report_root=Path(args.report_root),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-id", default="owasp_benchmark")
+    parser.add_argument("--raw-dir", required=True)
+    parser.add_argument("--run-id", default="local")
+    parser.add_argument("--report-root", default=str(EVALS_DIR / "reports"))
+    parser.add_argument("--repeats", type=int)
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args()
+    asyncio.run(_main_async(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/scoring/__init__.py
+++ b/evals/scoring/__init__.py
@@ -1,0 +1,2 @@
+"""Evaluation scoring primitives."""
+

--- a/evals/scoring/judge.py
+++ b/evals/scoring/judge.py
@@ -1,0 +1,5 @@
+"""Future LLM-as-judge implementation for M3+.
+
+No judge is used for M1 OWASP Benchmark hard-key triage.
+"""
+

--- a/evals/scoring/matcher.py
+++ b/evals/scoring/matcher.py
@@ -1,0 +1,6 @@
+"""Future set-matching cascade for M2+.
+
+M1 intentionally implements only hard-key SAST triage scoring in
+`evals.scoring.scorers.triage`.
+"""
+

--- a/evals/scoring/scorers/__init__.py
+++ b/evals/scoring/scorers/__init__.py
@@ -1,0 +1,2 @@
+"""Concrete score implementations."""
+

--- a/evals/scoring/scorers/calibration.py
+++ b/evals/scoring/scorers/calibration.py
@@ -1,0 +1,2 @@
+"""Future confidence calibration scorer."""
+

--- a/evals/scoring/scorers/classification.py
+++ b/evals/scoring/scorers/classification.py
@@ -1,0 +1,2 @@
+"""Future classification scorer for requirements and related labels."""
+

--- a/evals/scoring/scorers/grounding.py
+++ b/evals/scoring/scorers/grounding.py
@@ -1,0 +1,2 @@
+"""Future citation grounding and hallucination scorer."""
+

--- a/evals/scoring/scorers/set_detection.py
+++ b/evals/scoring/scorers/set_detection.py
@@ -1,0 +1,2 @@
+"""Future set-detection scorer for risks, threats, and compliance gaps."""
+

--- a/evals/scoring/scorers/triage.py
+++ b/evals/scoring/scorers/triage.py
@@ -1,0 +1,102 @@
+"""Binary SAST/DAST triage scoring for hard-key CWE datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.models.assessment import AssessmentReport, Vulnerability
+from evals.models import EvalCase
+
+
+@dataclass(frozen=True)
+class TriageRecord:
+    case_id: str
+    phase: str
+    skill_id: str
+    cwe: str
+    truth_label: str
+    predicted_positive: bool
+    repeat: int = 0
+
+    @property
+    def truth_positive(self) -> bool:
+        return self.truth_label == "true_positive"
+
+    @property
+    def outcome(self) -> str:
+        if self.truth_positive and self.predicted_positive:
+            return "tp"
+        if self.truth_positive and not self.predicted_positive:
+            return "fn"
+        if not self.truth_positive and self.predicted_positive:
+            return "fp"
+        return "tn"
+
+
+def record_from_report(
+    case: EvalCase,
+    report: AssessmentReport,
+    repeat: int,
+) -> TriageRecord:
+    """Build one binary triage record for an OWASP-style single-CWE case."""
+    if not case.ground_truth.vulnerabilities:
+        raise ValueError(f"Case has no vulnerability ground truth: {case.case_id}")
+    truth = case.ground_truth.vulnerabilities[0]
+    cwe = normalize_cwe(truth.cwe)
+    return TriageRecord(
+        case_id=case.case_id,
+        phase=case.phase,
+        skill_id=case.skill_id,
+        cwe=cwe,
+        truth_label=truth.label,
+        predicted_positive=_has_matching_vulnerability(report.vulnerabilities, cwe),
+        repeat=repeat,
+    )
+
+
+def score_records(records: list[TriageRecord]) -> dict[str, Any]:
+    """Compute accuracy, precision, recall, F1, and false-positive rate."""
+    counts = {"tp": 0, "fp": 0, "tn": 0, "fn": 0}
+    for record in records:
+        counts[record.outcome] += 1
+
+    tp = counts["tp"]
+    fp = counts["fp"]
+    tn = counts["tn"]
+    fn = counts["fn"]
+    total = tp + fp + tn + fn
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    return {
+        **counts,
+        "total": total,
+        "accuracy": _safe_div(tp + tn, total),
+        "precision": precision,
+        "recall": recall,
+        "f1": _safe_div(2 * precision * recall, precision + recall),
+        "false_positive_rate": _safe_div(fp, fp + tn),
+    }
+
+
+def normalize_cwe(value: object) -> str:
+    text = str(value or "").strip().upper()
+    if not text:
+        return ""
+    return text if text.startswith("CWE-") else f"CWE-{text}"
+
+
+def _has_matching_vulnerability(
+    vulnerabilities: list[Vulnerability],
+    expected_cwe: str,
+) -> bool:
+    for vuln in vulnerabilities:
+        if vuln.status == "false_positive":
+            continue
+        if normalize_cwe(vuln.cwe_id) == expected_cwe:
+            return True
+    return False
+
+
+def _safe_div(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0

--- a/evals/tests/__init__.py
+++ b/evals/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Evaluation harness tests."""
+

--- a/evals/tests/fixtures/owasp_benchmark/expectedresults-1.2.csv
+++ b/evals/tests/fixtures/owasp_benchmark/expectedresults-1.2.csv
@@ -1,0 +1,4 @@
+# test name, category, real vulnerability, cwe, Benchmark version: 1.2, 2016-06-1
+BenchmarkTest00001,pathtraver,true,22
+BenchmarkTest00002,sqli,false,89
+

--- a/evals/tests/fixtures/owasp_benchmark/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java
+++ b/evals/tests/fixtures/owasp_benchmark/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java
@@ -1,0 +1,9 @@
+package org.owasp.benchmark.testcode;
+
+public class BenchmarkTest00001 {
+    public void doPost() {
+        String path = "../../etc/passwd";
+        System.out.println(path);
+    }
+}
+

--- a/evals/tests/fixtures/owasp_benchmark/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00002.java
+++ b/evals/tests/fixtures/owasp_benchmark/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00002.java
@@ -1,0 +1,9 @@
+package org.owasp.benchmark.testcode;
+
+public class BenchmarkTest00002 {
+    public void doPost() {
+        String safe = "select * from users where id = ?";
+        System.out.println(safe);
+    }
+}
+

--- a/evals/tests/test_models.py
+++ b/evals/tests/test_models.py
@@ -1,0 +1,43 @@
+from evals.models import EvalCase
+
+
+def test_eval_case_round_trips_plan_example():
+    payload = {
+        "case_id": "tmbench-0007",
+        "dataset_id": "tmbench",
+        "phase": "design",
+        "skill_id": "ssdlc-design",
+        "inputs": [{"path": "inputs/tmbench-0007.md", "type": "markdown"}],
+        "ground_truth": {
+            "threats": [
+                {
+                    "component": "api",
+                    "stride": "S",
+                    "description": "Missing caller authentication.",
+                }
+            ],
+            "risk_items": [{"severity": "high", "description": "Auth gap."}],
+            "compliance_gaps": [
+                {
+                    "framework": "GDPR",
+                    "control_or_clause": "Art.32",
+                    "gap_description": "Encryption evidence is missing.",
+                }
+            ],
+            "vulnerabilities": [{"cwe": "CWE-89", "label": "true_positive"}],
+        },
+        "meta": {
+            "license": "example",
+            "contamination_risk": "high",
+            "annotators": 2,
+            "iaa": 0.71,
+        },
+    }
+
+    case = EvalCase.model_validate(payload)
+    restored = EvalCase.model_validate_json(case.model_dump_json())
+
+    assert restored == case
+    assert restored.phase == "design"
+    assert restored.ground_truth.vulnerabilities[0].cwe == "CWE-89"
+

--- a/evals/tests/test_owasp_adapter.py
+++ b/evals/tests/test_owasp_adapter.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from evals.adapters.owasp_benchmark import to_cases
+
+FIXTURE = Path(__file__).parent / "fixtures" / "owasp_benchmark"
+
+
+def test_owasp_adapter_reads_expected_results_fixture():
+    cases = list(to_cases(FIXTURE))
+
+    assert [case.case_id for case in cases] == [
+        "BenchmarkTest00001",
+        "BenchmarkTest00002",
+    ]
+    assert cases[0].phase == "testing"
+    assert cases[0].skill_id == "ssdlc-testing"
+    assert cases[0].inputs[0].type == "java"
+    assert cases[0].ground_truth.vulnerabilities[0].cwe == "CWE-22"
+    assert cases[0].ground_truth.vulnerabilities[0].label == "true_positive"
+    assert cases[1].ground_truth.vulnerabilities[0].cwe == "CWE-89"
+    assert cases[1].ground_truth.vulnerabilities[0].label == "false_positive"
+

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from app.models.assessment import AssessmentReport, Vulnerability
+from app.models.parser import ParsedDocument
+from evals.adapters.owasp_benchmark import to_cases
+from evals.models import RunConfig
+from evals.runner.run_eval import run_cases
+
+FIXTURE = Path(__file__).parent / "fixtures" / "owasp_benchmark"
+
+
+async def _deterministic_runner(
+    task_id: UUID,
+    parsed_documents: list[ParsedDocument],
+    **_: object,
+) -> AssessmentReport:
+    filename = parsed_documents[0].metadata.filename
+    vulnerabilities = []
+    if filename == "BenchmarkTest00001.java":
+        vulnerabilities.append(
+            Vulnerability(
+                id="v1",
+                title="Path traversal",
+                severity="high",
+                cwe_id="CWE-22",
+            )
+        )
+    return AssessmentReport(
+        task_id=str(task_id),
+        phase="testing",
+        status="completed",
+        summary="deterministic eval report",
+        vulnerabilities=vulnerabilities,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_stable_scorecards_with_assessment_service(tmp_path):
+    cases = list(to_cases(FIXTURE))
+    cfg = RunConfig(
+        run_id="fixture-run",
+        dataset_id="owasp_benchmark",
+        repeats=1,
+        provider="fixture",
+        model_id="deterministic",
+    )
+
+    first = await run_cases(
+        cases,
+        cfg,
+        input_root=FIXTURE,
+        report_root=tmp_path,
+        assessment_runner=_deterministic_runner,
+    )
+    second = await run_cases(
+        cases,
+        cfg.model_copy(update={"run_id": "fixture-run-2"}),
+        input_root=FIXTURE,
+        report_root=tmp_path,
+        assessment_runner=_deterministic_runner,
+    )
+
+    assert first["metrics"] == second["metrics"]
+    assert first["metrics"]["accuracy"] == 1.0
+    assert first["metrics"]["false_positive_rate"] == 0.0
+    assert (tmp_path / "fixture-run" / "scorecard.json").exists()
+    assert (tmp_path / "fixture-run" / "scorecard.md").exists()
+

--- a/evals/tests/test_triage_scorer.py
+++ b/evals/tests/test_triage_scorer.py
@@ -1,0 +1,64 @@
+from app.models.assessment import AssessmentReport, Vulnerability
+from evals.models import EvalCase, EvalGroundTruth, EvalInput, VulnerabilityTruth
+from evals.scoring.scorers.triage import record_from_report, score_records
+
+
+def _case(case_id: str, cwe: str, label: str) -> EvalCase:
+    return EvalCase(
+        case_id=case_id,
+        dataset_id="owasp_benchmark",
+        phase="testing",
+        skill_id="ssdlc-testing",
+        inputs=[EvalInput(path=f"{case_id}.java", type="java")],
+        ground_truth=EvalGroundTruth(
+            vulnerabilities=[VulnerabilityTruth(cwe=cwe, label=label)]
+        ),
+    )
+
+
+def _report(*vulnerabilities: Vulnerability) -> AssessmentReport:
+    return AssessmentReport(
+        task_id="task",
+        phase="testing",
+        status="completed",
+        summary="test",
+        vulnerabilities=list(vulnerabilities),
+    )
+
+
+def _vuln(cwe: str) -> Vulnerability:
+    return Vulnerability(
+        id="v1",
+        title="Finding",
+        severity="high",
+        cwe_id=cwe,
+    )
+
+
+def test_triage_scorer_computes_binary_metrics():
+    records = [
+        record_from_report(
+            _case("tp", "CWE-89", "true_positive"),
+            _report(_vuln("89")),
+            0,
+        ),
+        record_from_report(
+            _case("fp", "CWE-22", "false_positive"),
+            _report(_vuln("22")),
+            0,
+        ),
+        record_from_report(_case("fn", "CWE-78", "true_positive"), _report(), 0),
+        record_from_report(_case("tn", "CWE-79", "false_positive"), _report(), 0),
+    ]
+
+    metrics = score_records(records)
+
+    assert metrics["tp"] == 1
+    assert metrics["fp"] == 1
+    assert metrics["fn"] == 1
+    assert metrics["tn"] == 1
+    assert metrics["accuracy"] == 0.5
+    assert metrics["precision"] == 0.5
+    assert metrics["recall"] == 0.5
+    assert metrics["f1"] == 0.5
+    assert metrics["false_positive_rate"] == 0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docsentinel-mcp = "app.mcp_server:mcp.run"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["app*"]
+include = ["app*", "evals*"]
 
 # --- Tool Configuration ---
 


### PR DESCRIPTION
## Summary
- Add the `evals/` M0 scaffolding with `EvalCase`, `RunConfig`, registry, model matrix, and package wiring
- Implement the M1 OWASP Benchmark SAST triage path: fetch script, adapter, direct `AssessmentService` runner, hard-key CWE scorer, and JSON/Markdown scorecards
- Update the root README with evaluation harness usage and project layout references

## Data hygiene
- Raw OWASP Benchmark data is not committed
- `evals/datasets/owasp_benchmark/raw/`, downloads, and archives are ignored
- Registry records the source archive checksum and contamination risk
- Tests use a tiny synthetic fixture only

## Validation
- `.venv/bin/python -m pytest evals/tests` passed
- `.venv/bin/ruff check .` passed
- `.venv/bin/python -m pytest` passed: 108 tests
- Full OWASP adapter smoke read 2740 cases after fetch; raw data was removed before commit
- Tiny fixture scorecard smoke was stable across two invocations on the hard-key path

## Notes
- This PR intentionally stops at M1. Matcher, judge, set detection, grounding, calibration, and classification modules are stubs with docstrings for later milestones.
