### PR TITLE
ci: restore deterministic green builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            requirements.txt
+            requirements.lock
             requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --require-hashes -r requirements.lock
           pip install -r requirements-dev.txt
 
       - name: Lint with Ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            requirements.lock
+            requirements.txt
             requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --require-hashes -r requirements.lock
+          pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
       - name: Lint with Ruff

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "openapi-fetch": "^0.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.1"
+        "react-router-dom": "7.18.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -4070,9 +4070,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4092,12 +4092,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "openapi-fetch": "^0.17.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.1"
+    "react-router-dom": "7.18.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest
 pytest-asyncio
 pytest-cov
 httpx
+reportlab>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,8 +40,8 @@ lightrag-hku>=1.0.0
 
 # HTTP & async
 httpx>=0.26.0
-# FastMCP remains under mcp.server.fastmcp in the 1.x SDK used by the app.
-mcp>=1.0.0,<2.0.0
+# Pin the SDK whose public FastMCP import path is used by the app.
+mcp==1.28.1
 a2a-sdk[fastapi]==1.1.0
 
 # Database, auth & migrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,8 @@ lightrag-hku>=1.0.0
 
 # HTTP & async
 httpx>=0.26.0
-mcp>=1.0.0
+# FastMCP remains under mcp.server.fastmcp in the 1.x SDK used by the app.
+mcp>=1.0.0,<2.0.0
 a2a-sdk[fastapi]==1.1.0
 
 # Database, auth & migrations


### PR DESCRIPTION
## Summary

- pin the MCP SDK version that provides the FastMCP import path used by the backend
- add the missing ReportLab dependency for the prompt-injection corpus tests
- upgrade React Router to 7.18.2 to clear the production audit

## Root cause

The backend dependency manifest could resolve an MCP package without `mcp.server.fastmcp`; the prompt-injection corpus also required ReportLab but it was absent from development dependencies. The frontend lockfile still selected React Router 7.18.1, which has two high-severity advisories.

A first CI attempt also showed that the existing macOS-generated hash lock omits Linux-only CUDA transitive hashes, so CI continues to install the primary manifest while the MCP compatibility boundary is pinned explicitly.

## Validation

- `ruff check app tests evals`
- backend: 121 tests passed, 71% coverage
- evals: 5 tests passed
- OpenAPI contract check passed
- frontend: generated API types unchanged
- frontend: 6 tests passed
- `npm audit --omit=dev`: 0 vulnerabilities
- production build passed
