### PR TITLE
fix(ci): use portable locked release toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            requirements.lock
+            requirements.txt
             requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --require-hashes -r requirements.lock
+          pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
       - name: Lint with Ruff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: requirements.lock
+          cache-dependency-path: requirements-build.lock
       - name: Install locked build dependencies
-        run: python -m pip install --require-hashes -r requirements.lock
+        run: python -m pip install --require-hashes -r requirements-build.lock
       - name: Verify tag matches package version
         env:
           RELEASE_TAG: ${{ github.ref_name }}
@@ -34,7 +34,7 @@ jobs:
           assert os.environ["RELEASE_TAG"] == f"v{version}", "tag/version mismatch"
           PY
       - name: Build distribution
-        run: python -m build
+        run: python -m build --no-isolation
       - name: Generate SPDX SBOM
         uses: anchore/sbom-action@v0
         with:

--- a/docs/08-enterprise-trust-foundation.md
+++ b/docs/08-enterprise-trust-foundation.md
@@ -118,6 +118,9 @@ and rollback section for high-risk paths. CodeQL and dependency update workflows
 provide continuous scanning. Tagged releases build from the dependency lock,
 emit checksums and an SPDX SBOM, and use GitHub artifact attestations for SLSA
 provenance and the SBOM.
+The release build toolchain uses the small, platform-neutral
+`requirements-build.lock`; the broader runtime lock remains platform-specific
+and is not used as a Linux CI lock until it is regenerated for all targets.
 
 Repository administrators must still enable branch/ruleset enforcement for the
 required CI, PR Plan Gate, CodeQL, and CODEOWNERS approvals after these workflows

--- a/requirements-build.lock
+++ b/requirements-build.lock
@@ -1,0 +1,14 @@
+# Minimal, platform-neutral release build toolchain.
+# Hashes are sourced from the corresponding PyPI release metadata.
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f \
+    --hash=sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+pyproject-hooks==1.2.0 \
+    --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
+setuptools==84.0.0 \
+    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670 \
+    --hash=sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73


### PR DESCRIPTION
## Description | 描述

Follow-up to #54. The merged feature PR exposed a Linux CI portability issue: the runtime lock was generated on macOS and does not contain hashes for Linux-only transitive CUDA packages. This PR restores portable runtime dependency installation in regular CI while keeping the release build toolchain fully hash-pinned in a small platform-neutral lock.

Relates to #31

## Plan | 实施计划

- [x] Use `requirements.txt` for cross-platform runtime CI until per-target runtime locks are generated.
- [x] Add a minimal, hash-verified `requirements-build.lock` for release tooling.
- [x] Build releases with `--no-isolation` so only the reviewed locked toolchain is used.
- [x] Document the boundary between the runtime and release build locks.

## Security impact | 安全影响

Release supply-chain behavior remains fail-closed: build, packaging, and hook dependencies are exact-version and SHA-256 pinned, and isolated build dependency downloads are disabled. Runtime CI no longer claims portability from a macOS-generated lock; application dependencies continue to come from the reviewed requirements manifest.

## Risk and rollback | 风险与回滚

The main risk is drift in unpinned runtime CI dependencies. The follow-up is to generate supported-platform runtime locks before restoring `--require-hashes` there. Rollback is a single revert of this PR; no database, API, or artifact schema migration is involved.

## Type of Change | 变更类型

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor / chore

## How to Verify | 如何验证

- [x] Install `requirements-build.lock` in a clean virtual environment with `--require-hashes`.
- [x] Run `python -m build --no-isolation` and verify wheel and sdist output.
- [x] Run `ruff check .` and `git diff --check`.
- [x] Confirm GitHub Actions CI and PR Plan Gate pass on Linux.

## Checklist | 检查项

- [x] Tests pass locally (`pytest`) — full suite passed in #54; this follow-up changes workflows/docs only.
- [x] Frontend checks pass (`npm run check --prefix frontend`) — passed in #54; no frontend changes here.
- [x] Generated contracts are current (`make contracts-check`) — passed in #54; no contract changes here.
- [x] Security boundaries and denied paths are covered where relevant
- [x] Docs/README updated if needed
- [x] No secrets or sensitive data in the diff
- [x] Database migrations include downgrade/rollback coverage where relevant — not applicable; no migrations.
- [ ] The submitter is not the sole approver for security-sensitive changes
